### PR TITLE
Update breadcrumb links in user pages

### DIFF
--- a/src/app/(dashboard)/account-requests/page.tsx
+++ b/src/app/(dashboard)/account-requests/page.tsx
@@ -169,7 +169,7 @@ export default function AccountRequests() {
     <main className={styles.main}>
       <Breadcrumbs
         items={[
-          { title: "Dashboard", href: "/dashboard" },
+          // { title: "Dashboard", href: "/dashboard" },
           { title: "Account Requests", href: "/accounts" },
         ]}
       />

--- a/src/app/(dashboard)/accounts/[id]/page.tsx
+++ b/src/app/(dashboard)/accounts/[id]/page.tsx
@@ -122,7 +122,7 @@ export default function Account() {
     <main>
       <Breadcrumbs
         items={[
-          { title: "Dashboard", href: "/dashboard" },
+          // { title: "Dashboard", href: "/dashboard" },
           { title: "Accounts", href: "/accounts" },
           ...(!loading
             ? [

--- a/src/app/(dashboard)/accounts/[id]/transactions/page.tsx
+++ b/src/app/(dashboard)/accounts/[id]/transactions/page.tsx
@@ -69,7 +69,7 @@ export default function AccountTrx() {
     <main className={styles.main}>
       <Breadcrumbs
         items={[
-          { title: "Dashboard", href: "/dashboard" },
+          // { title: "Dashboard", href: "/dashboard" },
           { title: "Accounts", href: "/accounts" },
           { title: params.id, href: `/accounts/${params.id}` },
           {

--- a/src/app/(dashboard)/accounts/page.tsx
+++ b/src/app/(dashboard)/accounts/page.tsx
@@ -249,7 +249,7 @@ export default function Accounts() {
     <main className={styles.main}>
       <Breadcrumbs
         items={[
-          { title: "Dashboard", href: "/dashboard" },
+          // { title: "Dashboard", href: "/dashboard" },
           { title: "Accounts", href: "/accounts" },
         ]}
       />

--- a/src/app/(dashboard)/debit-requests/new/page.tsx
+++ b/src/app/(dashboard)/debit-requests/new/page.tsx
@@ -72,7 +72,7 @@ export default function DebitRequest() {
     <main className={styles.main}>
       <Breadcrumbs
         items={[
-          { title: "Dashboard", href: "/" },
+          // { title: "Dashboard", href: "/" },
           { title: "Debit Requests", href: "/debit-requests" },
           { title: "New Debit Request", href: "/debit-requests/new" },
         ]}

--- a/src/app/(dashboard)/debit-requests/page.tsx
+++ b/src/app/(dashboard)/debit-requests/page.tsx
@@ -142,7 +142,7 @@ export default function DebitRequests() {
     <main className={styles.main}>
       <Breadcrumbs
         items={[
-          { title: "Dashboard", href: "/dashboard" },
+          // { title: "Dashboard", href: "/dashboard" },
           { title: "Debit Requests", href: "/debit-requests" },
         ]}
       />

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -234,7 +234,7 @@ export default function Users() {
     <main className={styles.main}>
       <Breadcrumbs
         items={[
-          { title: "Dashboard", href: "/dashboard" },
+          // { title: "Dashboard", href: "/dashboard" },
           { title: "Settings", href: "/settings" },
         ]}
       />

--- a/src/app/(dashboard)/transactions/page.tsx
+++ b/src/app/(dashboard)/transactions/page.tsx
@@ -69,7 +69,7 @@ export default function AccountTrx() {
     <main className={styles.main}>
       <Breadcrumbs
         items={[
-          { title: "Dashboard", href: "/dashboard" },
+          // { title: "Dashboard", href: "/dashboard" },
           {
             title: "Transactions",
             href: `/accounts/transactions`,


### PR DESCRIPTION
This pull request updates the breadcrumb links in the user pages. The previous links to the "Dashboard" page have been commented out to remove them from the breadcrumb trail. This change ensures that the breadcrumb trail accurately reflects the user's navigation path.