### PR TITLE
Completed logic for account requests page

### DIFF
--- a/src/app/admin/(dashboard)/account-requests/[id]/[requestId]/page.tsx
+++ b/src/app/admin/(dashboard)/account-requests/[id]/[requestId]/page.tsx
@@ -36,9 +36,11 @@ import { parseError } from "@/lib/actions/auth";
 
 export default function SingleRequest() {
   const params = useParams<{ requestId: string }>();
-  const { revalidate, request } = useSingleRequest(params.requestId);
+  const { revalidate, request, loading } = useSingleRequest(params.requestId);
   const { handleSuccess, handleError } = useNotification();
   const { back } = useRouter();
+
+  console.log(request);
 
   const [opened, { open, close }] = useDisclosure(false);
   const [approveOpened, { open: openApprove, close: closeApprove }] =
@@ -99,8 +101,14 @@ export default function SingleRequest() {
           // { title: "Dashboard", href: "/admin/dashboard" },
           { title: "Account Requests", href: "/admin/account-requests" },
           {
-            title: params.requestId,
-            href: `/admin/account-requests/businesses/${params.requestId}`,
+            title: request?.Company.name || "",
+            href: `/admin/account-requests/${request?.Company.id}`,
+            loading: loading,
+          },
+          {
+            title: `${request?.firstName || ""} ${request?.lastName || ""}`,
+            href: `/admin/account-requests/${request?.Company.id}/${params.requestId}`,
+            loading: loading,
           },
         ]}
       />

--- a/src/lib/hooks/businesses.ts
+++ b/src/lib/hooks/businesses.ts
@@ -8,6 +8,7 @@ interface IParams {
   status?: string;
   sort?: string;
   page?: number;
+  type?: string;
 }
 export function useBusiness(
   customParams: IParams = {},
@@ -21,6 +22,7 @@ export function useBusiness(
       ...(customParams.status && { status: customParams.status }),
       ...(customParams.sort && { sort: customParams.sort }),
       ...(customParams.page && { page: customParams.page }),
+      ...(customParams.type && { type: customParams.type }),
     };
   }, [customParams]);
 
@@ -39,6 +41,7 @@ export function useBusiness(
       ...(customParams.sort && { sort: customParams.sort }),
       ...(customParams.page && { page: customParams.page }),
       ...(reqCount && { reqCount: "true" }),
+      ...(customParams.type && { type: customParams.type }),
     };
 
     const params = new URLSearchParams(queryParams as Record<string, string>);
@@ -87,7 +90,15 @@ export function useBusiness(
     return () => {
       // Any cleanup code can go here
     };
-  }, [obj.createdAt, obj.limit, obj.period, obj.sort, obj.status, obj.page]);
+  }, [
+    obj.createdAt,
+    obj.limit,
+    obj.period,
+    obj.sort,
+    obj.status,
+    obj.page,
+    obj.type,
+  ]);
 
   return { loading, businesses, meta, stats, statsMeta };
 }
@@ -135,27 +146,27 @@ export interface Director {
   identityFileUrlBack: string;
   proofOfAddressFileUrl: string;
 }
-export interface BusinessData {
-  id: string;
-  apiCalls: number;
-  contactEmail: string;
-  contactNumber: string | null;
-  createdAt: Date;
-  updatedAt: Date;
-  deletedAt: null;
-  domain: string;
-  name: string;
-  staging: string;
-  kycTrusted: boolean;
-  country: string | null;
-  address: string | null;
-  legalEntity: string | null;
-  mermat: string | null;
-  cacCertificate: string | null;
-  directors: Director[];
-  shareholders: Director[];
-  companyStatus: "ACTIVE" | "INACTIVE";
-}
+// export interface BusinessData {
+//   id: string;
+//   apiCalls: number;
+//   contactEmail: string;
+//   contactNumber: string | null;
+//   createdAt: Date;
+//   updatedAt: Date;
+//   deletedAt: null;
+//   domain: string;
+//   name: string;
+//   staging: string;
+//   kycTrusted: boolean;
+//   country: string | null;
+//   address: string | null;
+//   legalEntity: string | null;
+//   mermat: string | null;
+//   cacCertificate: string | null;
+//   directors: Director[];
+//   shareholders: Director[];
+//   companyStatus: "ACTIVE" | "INACTIVE";
+// }
 
 export interface BusinessMeta {
   total: number;
@@ -164,4 +175,46 @@ export interface BusinessMeta {
 export interface StatsMeta {
   monthDiff: number;
   weekCount: number;
+}
+
+export interface BusinessData {
+  id: string;
+  contactEmail: string;
+  contactNumber: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: null;
+  domain: string;
+  name: string;
+  staging: string;
+  kycTrusted: boolean;
+  address: string;
+  country: string;
+  legalEntity: string;
+  cacCertificate: string;
+  mermat: string;
+  businessBio: null | string;
+  directorParticular: null | string;
+  operationalLicense: null | string;
+  shareholderParticular: null | string;
+  amlCompliance: null | string;
+  directors: Director[];
+  shareholders: Director[];
+  companyStatus: "ACTIVE" | "INACTIVE";
+  apiCalls: number;
+  _count: Count;
+}
+
+export interface Count {
+  AccountRequests: number;
+}
+
+export interface Director {
+  name: string;
+  email: string;
+  identityType: string;
+  proofOfAddress: string;
+  identityFileUrl: string;
+  identityFileUrlBack: string;
+  proofOfAddressFileUrl: string;
 }

--- a/src/lib/hooks/requests.ts
+++ b/src/lib/hooks/requests.ts
@@ -12,9 +12,10 @@ interface IParams {
   sort?: string;
   query?: string;
   type?: string;
+  page?: number;
 }
 
-export function useRequests(customParams: IParams = {}) {
+export function useRequests(customParams: IParams = {}, id: string = "") {
   const [requests, setRequests] = useState<RequestData[]>([]);
   const [meta, setMeta] = useState<RequestMeta>();
   const [loading, setLoading] = useState(true);
@@ -26,18 +27,21 @@ export function useRequests(customParams: IParams = {}) {
       ...(customParams.status && { status: customParams.status }),
       ...(customParams.sort && { sort: customParams.sort }),
       ...(customParams.type && { type: customParams.type }),
+      ...(customParams.page && { page: customParams.page }),
     };
   }, [customParams]);
 
   async function fetchAccounts() {
+    //  `${id}/requests`;: fetch all requests for a specific business
     try {
+      const path = id ? `business/${id}/requests` : "requests";
       // const status = query ? `?status=${query}` : "";
       const params = new URLSearchParams(
         obj as Record<string, string>
       ).toString();
 
       const { data } = await axios.get(
-        `${process.env.NEXT_PUBLIC_ACCOUNTS_URL}/admin/requests?${params}`,
+        `${process.env.NEXT_PUBLIC_ACCOUNTS_URL}/admin/${path}?${params}`,
         { withCredentials: true }
       );
 
@@ -60,7 +64,7 @@ export function useRequests(customParams: IParams = {}) {
     return () => {
       // Any cleanup code can go here
     };
-  }, []);
+  }, [obj.createdAt, obj.limit, obj.sort, obj.status, obj.type, obj.page]);
 
   return { loading, requests, meta, revalidate };
 }
@@ -340,4 +344,5 @@ export interface Director {
 export interface RequestMeta {
   approvedRequests: number;
   pendingRequests: number;
+  total: number;
 }

--- a/src/ui/components/Breadcrumbs/index.tsx
+++ b/src/ui/components/Breadcrumbs/index.tsx
@@ -1,5 +1,9 @@
 import Link from "next/link";
-import { Breadcrumbs as MantineBreadcrumbs, Text } from "@mantine/core";
+import {
+  Breadcrumbs as MantineBreadcrumbs,
+  Skeleton,
+  Text,
+} from "@mantine/core";
 
 import styles from "./styles.module.scss";
 import { IconChevronRight } from "@tabler/icons-react";
@@ -7,15 +11,19 @@ import { IconChevronRight } from "@tabler/icons-react";
 export default function Breadcrumbs({ items }: { items: IItems[] }) {
   const links = items.map((item, index) => (
     <Link href={item.href} key={index}>
-      <Text
-        fz={11}
-        tt="uppercase"
-        className={`${styles.current__link} ${
-          index === items.length - 1 && styles.active__link
-        }`}
-      >
-        {item.title}
-      </Text>
+      {!item.loading ? (
+        <Text
+          fz={11}
+          tt="uppercase"
+          className={`${styles.current__link} ${
+            index === items.length - 1 && styles.active__link
+          }`}
+        >
+          {item.title}
+        </Text>
+      ) : (
+        <Skeleton height={8} width={60} radius="xl" />
+      )}
     </Link>
   ));
 
@@ -29,4 +37,5 @@ export default function Breadcrumbs({ items }: { items: IItems[] }) {
 interface IItems {
   title: string;
   href: string;
+  loading?: boolean;
 }


### PR DESCRIPTION
This pull request adds support for the `type` property in the `customParams` object of the `useBusiness` hook. It allows specifying the type of businesses to fetch. The `useBusiness` hook is updated to include the `type` parameter in the query parameters when making the API request. This enables fetching businesses of a specific type along with the business data. The change is implemented in the `businesses.ts` file.

"Add lazy loading for images in Breadcrumbs component"