### PR TITLE
Refactor BusinessAccountRequests and Transactions components

### DIFF
--- a/src/app/(dashboard)/payouts/(tabs)/Inquiries.tsx
+++ b/src/app/(dashboard)/payouts/(tabs)/Inquiries.tsx
@@ -80,7 +80,7 @@ export const InquiriesTab = () => {
           <InquiryTableRows
             data={inquiries}
             // data={inquiriesData}
-            searchProps={["pruneReference", "inquiryType"]}
+            searchProps={["Transaction.centrolinkRef", "type"]}
             search={debouncedSearch}
             business
           />

--- a/src/app/(dashboard)/payouts/InquiryModal.tsx
+++ b/src/app/(dashboard)/payouts/InquiryModal.tsx
@@ -44,7 +44,13 @@ export const InquiryModal = ({
       const { reason, file, extension } = form.values;
       await axios.post(
         `${process.env.NEXT_PUBLIC_PAYOUT_URL}/payout/transactions/${trxId}/${type}`,
-        { reason, supportingDocument: file, extension },
+        {
+          reason,
+          ...(file && {
+            supportingDocument: file,
+            extension,
+          }),
+        },
         { headers: { Authorization: `Bearer ${Cookies.get("auth")}` } }
       );
 

--- a/src/app/admin/(dashboard)/account-requests/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/account-requests/[id]/page.tsx
@@ -153,8 +153,8 @@ function BusinessAccountRequests() {
     );
   };
 
-  const handleRowClick = (id: string, status: string) => {
-    if (status === "APPROVED") return push(`/admin/accounts/${params.id}`);
+  const handleRowClick = (id: string, status: string, accountId: string) => {
+    if (status === "APPROVED") return push(`/admin/accounts/${accountId}`);
 
     push(`/admin/account-requests/${params.id}/${id}`);
   };
@@ -166,7 +166,9 @@ function BusinessAccountRequests() {
   ).map((element, index) => (
     <TableTr
       key={index}
-      onClick={() => handleRowClick(element.id, element.status)}
+      onClick={() =>
+        handleRowClick(element.id, element.status, element.Account?.id ?? "")
+      }
       style={{ cursor: "pointer" }}
     >
       <TableTd
@@ -199,7 +201,7 @@ function BusinessAccountRequests() {
         items={[
           { title: "Account Creation", href: "/admin/account-requests" },
           {
-            title: requests[0]?.Company.name,
+            title: meta?.companyName ?? "",
             href: `/admin/account-requests/${params.id}`,
             loading: loading,
           },
@@ -230,14 +232,14 @@ function BusinessAccountRequests() {
         <Group gap={9}>
           {!loading ? (
             <Avatar color="var(--prune-primary-700)" size={39} variant="filled">
-              {getInitials(requests[0]?.Company.name || "")}
+              {getInitials(meta?.companyName || "")}
             </Avatar>
           ) : (
             <Skeleton circle h={39} w={39} />
           )}
           {!loading ? (
             <Text fz={20} fw={600} c="var(--prune-text-gray-700)">
-              {requests[0]?.Company.name}
+              {meta?.companyName}
             </Text>
           ) : (
             <Skeleton h={10} w={100} />

--- a/src/app/admin/(dashboard)/payouts/(tabs)/PayoutTransactions/(tabs)/All.tsx
+++ b/src/app/admin/(dashboard)/payouts/(tabs)/PayoutTransactions/(tabs)/All.tsx
@@ -96,7 +96,7 @@ export const AllPayoutTransactions = ({
         // rows={rows}
         rows={
           <PayoutTransactionTableRows
-            data={transactions.toReversed()}
+            data={transactions}
             searchProps={[
               "senderIban",
               "recipientIban",

--- a/src/app/admin/(dashboard)/payouts/(tabs)/PayoutTransactions/(tabs)/Cancelled.tsx
+++ b/src/app/admin/(dashboard)/payouts/(tabs)/PayoutTransactions/(tabs)/Cancelled.tsx
@@ -91,7 +91,7 @@ export const CancelledPayoutTransactions = ({
         // rows={rows}
         rows={
           <PayoutTransactionTableRows
-            data={transactions.toReversed()}
+            data={transactions}
             searchProps={[
               "senderIban",
               "recipientIban",

--- a/src/app/admin/(dashboard)/requests/(tabs)/payouts/AllPayoutRequests.tsx
+++ b/src/app/admin/(dashboard)/requests/(tabs)/payouts/AllPayoutRequests.tsx
@@ -47,20 +47,19 @@ export const AllPayoutRequests = () => {
     status,
     endDate,
     date,
-    recipientName,
-    recipientIban,
-    senderName,
+    beneficiaryName,
+    destinationIban,
     senderIban,
-    bank,
+    destinationBank,
   } = Object.fromEntries(searchParams.entries());
 
   const queryParams = {
     ...(date && { date: dayjs(date).format("YYYY-MM-DD") }),
     ...(endDate && { endDate: dayjs(endDate).format("YYYY-MM-DD") }),
     ...(status && { status: status.toUpperCase() }),
-    ...(recipientName && { recipientName }),
-    ...(recipientIban && { recipientIban }),
-    ...(bank && { bank }),
+    ...(beneficiaryName && { beneficiaryName }),
+    ...(destinationIban && { destinationIban }),
+    ...(destinationBank && { destinationBank }),
     ...(senderIban && { senderIban }),
     limit: parseInt(limit ?? "100", 10),
     page: active,
@@ -106,12 +105,12 @@ export const AllPayoutRequests = () => {
       >
         <TextBox
           placeholder="Beneficiary Name"
-          {...form.getInputProps("recipientName")}
+          {...form.getInputProps("beneficiaryName")}
         />
 
         <TextBox
           placeholder="Beneficiary IBAN"
-          {...form.getInputProps("recipientIban")}
+          {...form.getInputProps("destinationIban")}
         />
 
         <TextBox
@@ -119,7 +118,10 @@ export const AllPayoutRequests = () => {
           {...form.getInputProps("senderIban")}
         />
 
-        <TextBox placeholder="Bank" {...form.getInputProps("bank")} />
+        <TextBox
+          placeholder="Bank"
+          {...form.getInputProps("destinationBank")}
+        />
       </Filter>
 
       <TableComponent

--- a/src/app/admin/(dashboard)/requests/(tabs)/payouts/PendingRequests.tsx
+++ b/src/app/admin/(dashboard)/requests/(tabs)/payouts/PendingRequests.tsx
@@ -59,22 +59,20 @@ export const PendingPayoutRequests = () => {
   const searchParams = useSearchParams();
 
   const {
-    status,
     endDate,
     date,
-    recipientName,
-    recipientIban,
-    senderName,
+    beneficiaryName,
+    destinationIban,
     senderIban,
-    bank,
+    destinationBank,
   } = Object.fromEntries(searchParams.entries());
 
   const queryParams = {
     ...(date && { date: dayjs(date).format("YYYY-MM-DD") }),
     ...(endDate && { endDate: dayjs(endDate).format("YYYY-MM-DD") }),
-    ...(recipientName && { recipientName }),
-    ...(recipientIban && { recipientIban }),
-    ...(bank && { bank }),
+    ...(beneficiaryName && { beneficiaryName }),
+    ...(destinationIban && { destinationIban }),
+    ...(destinationBank && { destinationBank }),
     ...(senderIban && { senderIban }),
     limit: parseInt(limit ?? "100", 10),
     page: active,
@@ -149,12 +147,12 @@ export const PendingPayoutRequests = () => {
       >
         <TextBox
           placeholder="Beneficiary Name"
-          {...form.getInputProps("recipientName")}
+          {...form.getInputProps("beneficiaryName")}
         />
 
         <TextBox
           placeholder="Beneficiary IBAN"
-          {...form.getInputProps("recipientIban")}
+          {...form.getInputProps("destinationIban")}
         />
 
         <TextBox
@@ -162,7 +160,10 @@ export const PendingPayoutRequests = () => {
           {...form.getInputProps("senderIban")}
         />
 
-        <TextBox placeholder="Bank" {...form.getInputProps("bank")} />
+        <TextBox
+          placeholder="Bank"
+          {...form.getInputProps("destinationBank")}
+        />
       </Filter>
 
       <TableComponent

--- a/src/lib/hooks/requests.ts
+++ b/src/lib/hooks/requests.ts
@@ -235,12 +235,14 @@ export function usePayoutTransactionRequests(customParams: IParams = {}) {
       ...(customParams.endDate && { endDate: customParams.endDate }),
       ...(customParams.status && { status: customParams.status }),
       ...(customParams.not && { not: customParams.not }),
-      ...(customParams.bank && { bank: customParams.bank }),
-      ...(customParams.recipientIban && {
-        recipientIban: customParams.recipientIban,
+      ...(customParams.destinationBank && {
+        bank: customParams.destinationBank,
       }),
-      ...(customParams.recipientName && {
-        recipientName: customParams.recipientName,
+      ...(customParams.destinationIban && {
+        recipientIban: customParams.destinationIban,
+      }),
+      ...(customParams.beneficiaryName && {
+        recipientName: customParams.beneficiaryName,
       }),
       ...(customParams.senderIban && { senderIban: customParams.senderIban }),
       ...(customParams.page && { page: customParams.page }),

--- a/src/lib/hooks/requests.ts
+++ b/src/lib/hooks/requests.ts
@@ -921,6 +921,7 @@ export interface RequestMeta {
   pendingRequests: number;
   inactiveAccounts: number;
   total: number;
+  companyName: string;
 }
 
 export interface PayoutAccount {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -538,6 +538,9 @@ export const FilterValues = {
   amount: null,
   business: "",
   bank: "",
+  beneficiaryName: "",
+  destinationIban: "",
+  destinationBank: "",
 };
 
 export const FilterSchema = z.object({
@@ -558,6 +561,9 @@ export const FilterSchema = z.object({
   amount: z.number().nullable(),
   business: z.string().nullable(),
   bank: z.string().nullable(),
+  beneficiaryName: z.string().nullable(),
+  destinationIban: z.string().nullable(),
+  destinationBank: z.string().nullable(),
 });
 
 export type FilterType = z.infer<typeof FilterSchema>;
@@ -586,6 +592,9 @@ export interface IParams {
   not?: string;
   query?: string;
   bank?: string;
+  beneficiaryName?: string;
+  destinationIban?: string;
+  destinationBank?: string;
 }
 
 export const removeDirectorValues = {

--- a/src/ui/components/SingleAccount/(tabs)/Transactions.tsx
+++ b/src/ui/components/SingleAccount/(tabs)/Transactions.tsx
@@ -78,7 +78,7 @@ export const Transactions = ({ transactions, loading, payout }: Props) => {
       <InfoCards title="Overview" details={overviewDetails} />
 
       <Group mt={32} justify="space-between">
-        <SearchInput />
+        <SearchInput search={search} setSearch={setSearch} />
 
         <Group gap={12}>
           <SecondaryBtn text="Filter" icon={IconListTree} />
@@ -146,4 +146,10 @@ export const Transactions = ({ transactions, loading, payout }: Props) => {
   );
 };
 
-const searchProps = ["senderIban", "recipientIban", "recipientBankAddress"];
+const searchProps = [
+  "senderIban",
+  "recipientIban",
+  "recipientBankAddress",
+  "senderName",
+  "recipientName",
+];

--- a/src/ui/components/SingleAccount/index.tsx
+++ b/src/ui/components/SingleAccount/index.tsx
@@ -47,7 +47,12 @@ import advancedFormat from "dayjs/plugin/advancedFormat";
 dayjs.extend(advancedFormat);
 
 import TransactionStatistics from "@/app/admin/(dashboard)/accounts/[id]/TransactionStats";
-import { approvedBadgeColor, formatNumber, getUserType } from "@/lib/utils";
+import {
+  approvedBadgeColor,
+  formatNumber,
+  getInitials,
+  getUserType,
+} from "@/lib/utils";
 import Link from "next/link";
 import InfoCards from "../Cards/InfoCards";
 import { DonutChartComponent } from "../Charts";
@@ -1056,10 +1061,7 @@ export const DefaultAccountHead = ({
         <Group gap={12} align="center">
           {!loading ? (
             <Avatar size="lg" color="var(--prune-primary-700)" variant="filled">
-              {account?.accountName
-                .split(" ")
-                .map((item) => item.charAt(0))
-                .join("")}
+              {getInitials(account?.accountName ?? "")}
             </Avatar>
           ) : (
             <Skeleton circle h={50} w={50} />
@@ -1067,7 +1069,7 @@ export const DefaultAccountHead = ({
 
           <Stack gap={2}>
             {!loading ? (
-              <Group gap={15}>
+              <Group gap={5}>
                 <Text fz={24} className={styles.main__header__text} m={0} p={0}>
                   {account?.accountName}
                 </Text>
@@ -1148,14 +1150,14 @@ export const DefaultAccountHead = ({
         action={handleAccountTrust}
         customApproveMessage="Yes, Proceed"
         icon={
-          business?.kycTrusted ? (
+          account?.isTrusted ? (
             <IconExclamationCircle color="#C6A700" />
           ) : (
             <IconShieldCheck color="#12B76A" />
           )
         }
         processing={processingTrust}
-        color={business?.kycTrusted ? "#F9F6E6" : "#ECFDF3"}
+        color={account?.isTrusted ? "#F9F6E6" : "#ECFDF3"}
       />
 
       <Modal


### PR DESCRIPTION
This pull request includes refactoring of the BusinessAccountRequests and Transactions components. In the BusinessAccountRequests component, the handleRowClick function has been refactored to include an accountId parameter and route approved account requests to the single account page when clicked. The companyName key from the meta data is now used to display the company name on the component. In the Transactions component, the searchProps have been updated to include "Transaction.centrolinkRef" and "type" instead of "pruneReference" and "inquiryType". The InquiryModal component now has optional fields for supportingDocument and extension when making a POST request. The InquiryPage and admin InquiryPage components have been updated with useRef to reset the file input field, and the title and text for reopening and closing query tickets have been updated. The searchProps in the Transactions component have been updated to include "senderName" and "recipientName" in addition to existing properties. The filter in the AllPayoutRequests and PendingPayoutRequests components has been refactored to match what the backend is expecting. The usePayoutTransactionRequests hook has been updated to include the new filter properties. The AllPayoutTransactions and CancelledPayoutTransactions components have been updated to remove the toReversed method from the data prop. The FilterValues interface and FilterSchema have been updated to include new filter properties. The AllPayoutRequests and PendingPayoutRequests components have been updated to include the new filter properties in the searchParams. The handleRowClick function in the BusinessAccountRequests component has been updated to include the accountId parameter when routing to the single account page. The DefaultAccountHead component has been updated to use the getInitials function to display the account initials in the Avatar component.