### PR TITLE
Refactor PayoutDrawer to update BIC value

### DIFF
--- a/src/app/(dashboard)/payouts/(tabs)/PayoutTransactions/(tabs)/All.tsx
+++ b/src/app/(dashboard)/payouts/(tabs)/PayoutTransactions/(tabs)/All.tsx
@@ -86,7 +86,7 @@ export const AllPayoutTransactions = () => {
         opened={opened}
         toggle={toggle}
         form={form}
-        customStatusOption={["PENDING", "COMPLETED", "REJECTED"]}
+        customStatusOption={["PENDING", "CONFIRMED", "REJECTED"]}
       >
         <TextBox
           placeholder="Sender Name"

--- a/src/app/(dashboard)/payouts/PayoutDrawer.tsx
+++ b/src/app/(dashboard)/payouts/PayoutDrawer.tsx
@@ -86,7 +86,7 @@ export const PayoutTransactionDrawer = () => {
       transaction?.company?.name ?? defaultTransaction?.company?.name ?? "N/A",
     "Account Type": "Payout Account",
     IBAN: data?.recipientIban,
-    BIC: data?.recipientBic,
+    BIC: "ARPYGB21XXX",
   };
 
   const beneficiaryDetails = {

--- a/src/app/admin/(dashboard)/payouts/(tabs)/PayoutTransactions/(tabs)/All.tsx
+++ b/src/app/admin/(dashboard)/payouts/(tabs)/PayoutTransactions/(tabs)/All.tsx
@@ -97,7 +97,7 @@ export const AllPayoutTransactions = () => {
         opened={opened}
         toggle={toggle}
         form={form}
-        customStatusOption={["PENDING", "COMPLETED", "REJECTED"]}
+        customStatusOption={["PENDING", "CONFIRMED", "REJECTED"]}
       >
         <TextBox
           placeholder="Sender Name"

--- a/src/app/admin/(dashboard)/transactions/page.tsx
+++ b/src/app/admin/(dashboard)/transactions/page.tsx
@@ -151,7 +151,7 @@ function TransactionForAccount() {
     },
   ];
 
-  const customStatusOption = ["PENDING", "COMPLETED", "REJECTED", "CANCELLED"];
+  const customStatusOption = ["PENDING", "CONFIRMED", "REJECTED", "CANCELLED"];
 
   const form = useForm<FilterType>({
     initialValues: FilterValues,

--- a/src/lib/hooks/transactions.ts
+++ b/src/lib/hooks/transactions.ts
@@ -748,7 +748,7 @@ export interface TransactionType {
   amount: number;
   reference: string;
   centrolinkRef: string;
-  status: "PENDING" | "COMPLETED" | "REJECTED" | "CANCELLED";
+  status: "PENDING" | "CONFIRMED" | "REJECTED" | "CANCELLED";
   createdAt: Date;
   updatedAt: Date;
   destinationFirstName: string;

--- a/src/ui/components/SingleAccount/(tabs)/Transactions.tsx
+++ b/src/ui/components/SingleAccount/(tabs)/Transactions.tsx
@@ -111,7 +111,7 @@ export const Transactions = ({ transactions, loading, payout }: Props) => {
         opened={openedFilter}
         toggle={toggle}
         form={form}
-        customStatusOption={["PENDING", "COMPLETED", "REJECTED", "CANCELLED"]}
+        customStatusOption={["PENDING", "CONFIRMED", "REJECTED", "CANCELLED"]}
       >
         <TextBox
           placeholder="Sender Name"

--- a/src/ui/components/TableRows/index.tsx
+++ b/src/ui/components/TableRows/index.tsx
@@ -304,7 +304,7 @@ export const PayoutTrxReqTableRows = ({
             status: element.status as unknown as
               | "PENDING"
               | "REJECTED"
-              | "COMPLETED"
+              | "CONFIRMED"
               | "CANCELLED",
           });
         }}


### PR DESCRIPTION
This pull request refactors the PayoutDrawer component to update the BIC value. The "BIC" field is now hardcoded as "ARPYGB21XXX" instead of being dynamically fetched from the data. This change ensures that the BIC value is consistently set to the specified value.

Refactor status options to use "CONFIRMED" instead of "COMPLETED"