### PR TITLE
Fix flickering of transactions and refresh issue in PayoutTrx component

### DIFF
--- a/src/app/(dashboard)/payouts/page.tsx
+++ b/src/app/(dashboard)/payouts/page.tsx
@@ -172,6 +172,7 @@ function PayoutTrx() {
         defaultValue={tabs.find((t) => t.value === tab)?.value ?? tabs[0].value}
         tabs={tabs}
         mt={28}
+        keepMounted={false}
       >
         <TabsPanel value={tabs[0].value}>
           <PayoutAccount loading={loading} meta={meta} />

--- a/src/ui/components/Filter/index.tsx
+++ b/src/ui/components/Filter/index.tsx
@@ -104,7 +104,7 @@ export default function Filter<T>({
 
         <SecondaryBtn icon={IconX} action={toggle} text="Close" p={10} />
       </Group>
-      <Group gap={12} align="center" h={40}>
+      <Flex gap={12} align="center" mih={40} wrap="wrap">
         {children}
 
         {!noDate && (
@@ -178,7 +178,7 @@ export default function Filter<T>({
             Clear
           </Button>
         </Flex>
-      </Group>
+      </Flex>
     </Collapse>
   );
 }

--- a/src/ui/components/SingleAccount/(defaultTabs)/Transactions.tsx
+++ b/src/ui/components/SingleAccount/(defaultTabs)/Transactions.tsx
@@ -163,7 +163,7 @@ const PayoutRowComponent = ({
   };
 
   const { setData, open } = Transaction();
-  return data?.reverse().map((element) => (
+  return data?.map((element) => (
     <TableTr
       key={element.id}
       onClick={() => {

--- a/src/ui/components/TableRows/index.tsx
+++ b/src/ui/components/TableRows/index.tsx
@@ -30,7 +30,7 @@ export const BusinessTransactionTableRows = ({
 }) => {
   const { open, setData } = Transaction();
   return frontendPagination(
-    filteredSearch(data.reverse(), searchProps, search),
+    filteredSearch(data, searchProps, search),
     active,
     parseInt(limit ?? "10", 10)
   ).map((element) => (
@@ -98,7 +98,7 @@ export const IssuedTransactionTableRows = ({
 }) => {
   const { open, setData } = Transaction();
   return frontendPagination(
-    filteredSearch(data.reverse(), searchProps, search),
+    filteredSearch(data, searchProps, search),
     active,
     parseInt(limit ?? "10", 10)
   ).map((element) => (
@@ -178,7 +178,7 @@ export const PayoutTransactionTableRows = ({
 }) => {
   const { open, setData } = Transaction();
   return frontendPagination(
-    filteredSearch(data.reverse(), searchProps, search),
+    filteredSearch(data, searchProps, search),
     active,
     parseInt(limit ?? "10", 10)
   ).map((element) => (
@@ -275,7 +275,7 @@ export const PayoutTrxReqTableRows = ({
   searchProps: string[];
 }) => {
   const { open, setData } = Transaction();
-  return filteredSearch(data.toReversed(), searchProps, search).map(
+  return filteredSearch(data, searchProps, search).map(
     (element: PayoutTransactionRequest) => (
       <TableTr
         key={element.id}


### PR DESCRIPTION
This pull request includes three commits. The first commit resolves the flickering of transactions on a table when the drawer is opened by removing the reverse() on the transaction data. The second commit refactors the PayoutTrx component to remove the keepMounted prop, which fixes the issue where the Inquiries tab needs to be refreshed upon creating a new inquiry. The third commit merges the 'develop' branch into the 'gilead/payout-corrections' branch.