### PR TITLE
Refactor TransactionForAccount component to use meta data for default account transactions

### DIFF
--- a/src/app/admin/(dashboard)/transactions/page.tsx
+++ b/src/app/admin/(dashboard)/transactions/page.tsx
@@ -79,10 +79,16 @@ function TransactionForAccount() {
 
   const { loading, transactions, meta } = useTransactions(undefined, param);
 
-  const { transactions: payoutTransactions, loading: loadingPayout } =
-    usePayoutTransactions(param);
-  const { transactions: defaultTransactions, loading: loadingDefault } =
-    useDefaultAccountTransactions(param);
+  const {
+    transactions: payoutTransactions,
+    loading: loadingPayout,
+    meta: payoutMeta,
+  } = usePayoutTransactions(param);
+  const {
+    transactions: defaultTransactions,
+    loading: loadingDefault,
+    meta: defaultMeta,
+  } = useDefaultAccountTransactions(param);
 
   const [opened, { toggle }] = useDisclosure(false);
   const [openedIssued, { toggle: toggleIssuedFilter }] = useDisclosure(false);
@@ -120,34 +126,38 @@ function TransactionForAccount() {
   const defaultInfoDetails = [
     {
       title: "Total Balance",
-      value: defaultTransactions.reduce((acc, cur) => acc + cur.amount, 0),
+      value: defaultMeta?.totalAmount || 0,
+      // value: defaultTransactions.reduce((acc, cur) => acc + cur.amount, 0),
       formatted: true,
       currency: "EUR",
       locale: "en-GB",
     },
     {
       title: "Money In",
-      value:
-        defaultTransactions
-          .filter((trx) => trx.type === "CREDIT")
-          .reduce((acc, cur) => acc + cur.amount, 0) || 0,
+      value: defaultMeta?.in || 0,
+      // value:
+      //   defaultTransactions
+      //     .filter((trx) => trx.type === "CREDIT")
+      //     .reduce((acc, cur) => acc + cur.amount, 0) || 0,
       formatted: true,
       currency: "EUR",
       locale: "en-GB",
     },
     {
       title: "Money Out",
-      value:
-        defaultTransactions
-          .filter((trx) => trx.type === "DEBIT")
-          .reduce((acc, cur) => acc + cur.amount, 0) || 0,
+      value: defaultMeta?.out || 0,
+      // value:
+      //   defaultTransactions
+      //     .filter((trx) => trx.type === "DEBIT")
+      //     .reduce((acc, cur) => acc + cur.amount, 0) || 0,
       formatted: true,
       currency: "EUR",
       locale: "en-GB",
     },
     {
       title: "Total Transactions",
-      value: defaultTransactions.length,
+      // value: defaultTransactions.length,
+      value: defaultMeta?.total || 0,
     },
   ];
 

--- a/src/lib/hooks/transactions.ts
+++ b/src/lib/hooks/transactions.ts
@@ -3,7 +3,6 @@ import { useState, useEffect, useMemo } from "react";
 import Cookies from "js-cookie";
 import { BusinessData } from "./businesses";
 import { IParams } from "../schema";
-import { custom } from "zod";
 
 export function useTransactions(id: string = "", customParams: IParams = {}) {
   const [transactions, setTransactions] = useState<TransactionType[]>([]);
@@ -171,24 +170,41 @@ export function useBusinessTransactions(
   const [meta, setMeta] = useState<BusinessTrxMeta | null>(null);
   const [loading, setLoading] = useState(true);
 
-  async function fetchTrx() {
-    const queryParams = {
+  const obj = useMemo(() => {
+    return {
       ...(customParams.limit && { limit: customParams.limit }),
+      ...(customParams.not && { not: customParams.not }),
+      ...(customParams.page && { page: customParams.page }),
       ...(customParams.date && { date: customParams.date }),
       ...(customParams.endDate && { endDate: customParams.endDate }),
       ...(customParams.status && { status: customParams.status }),
-      ...(customParams.page && { page: customParams.page }),
+      ...(customParams.endDate && { endDate: customParams.endDate }),
       ...(customParams.type && { type: customParams.type }),
-      ...(customParams.senderName && { senderName: customParams.senderName }),
-      ...(customParams.recipientName && {
-        recipientName: customParams.recipientName,
-      }),
       ...(customParams.recipientIban && {
         recipientIban: customParams.recipientIban,
       }),
+      ...(customParams.recipientName && {
+        recipientName: customParams.recipientName,
+      }),
+      ...(customParams.senderName && { senderName: customParams.senderName }),
     };
+  }, [customParams]);
 
-    const params = new URLSearchParams(queryParams as Record<string, string>);
+  const {
+    limit,
+    page,
+    date,
+    endDate,
+    status,
+    type,
+    recipientIban,
+    recipientName,
+    senderName,
+    not,
+  } = obj;
+
+  async function fetchTrx() {
+    const params = new URLSearchParams(obj as Record<string, string>);
     try {
       setLoading(true);
       const path = id ? `` : "transactions";
@@ -215,15 +231,16 @@ export function useBusinessTransactions(
       // Any cleanup code can go here
     };
   }, [
-    customParams.date,
-    customParams.limit,
-    customParams.status,
-    customParams.endDate,
-    customParams.type,
-    customParams.senderName,
-    customParams.recipientName,
-    customParams.recipientIban,
-    customParams.page,
+    limit,
+    page,
+    date,
+    endDate,
+    status,
+    type,
+    recipientIban,
+    recipientName,
+    senderName,
+    not,
   ]);
 
   return { loading, transactions, meta, revalidate };
@@ -231,15 +248,57 @@ export function useBusinessTransactions(
 
 export function useDefaultAccountTransactions(customParams: IParams = {}) {
   const [transactions, setTransactions] = useState<TransactionType[]>([]);
-  const [meta, setMeta] = useState<BusinessTrxMeta | null>(null);
+  const [meta, setMeta] = useState<Meta | null>(null);
   const [loading, setLoading] = useState(true);
+
+  const obj = useMemo(() => {
+    return {
+      ...(customParams.limit && { limit: customParams.limit }),
+      ...(customParams.not && { not: customParams.not }),
+      ...(customParams.page && { page: customParams.page }),
+      ...(customParams.date && { date: customParams.date }),
+      ...(customParams.endDate && { endDate: customParams.endDate }),
+      ...(customParams.status && { status: customParams.status }),
+      ...(customParams.endDate && { endDate: customParams.endDate }),
+      ...(customParams.type && { type: customParams.type }),
+      ...(customParams.recipientIban && {
+        recipientIban: customParams.recipientIban,
+      }),
+      ...(customParams.recipientName && {
+        recipientName: customParams.recipientName,
+      }),
+      ...(customParams.senderName && { senderName: customParams.senderName }),
+    };
+  }, [customParams]);
+
+  const {
+    limit,
+    page,
+    date,
+    endDate,
+    status,
+    type,
+    recipientIban,
+    recipientName,
+    senderName,
+    not,
+  } = obj;
 
   async function fetchTrx() {
     const queryParams = {
       ...(customParams.limit && { limit: customParams.limit }),
       ...(customParams.date && { date: customParams.date }),
+      ...(customParams.endDate && { endDate: customParams.endDate }),
       ...(customParams.status && { status: customParams.status }),
       ...(customParams.page && { page: customParams.page }),
+      ...(customParams.type && { type: customParams.type }),
+      ...(customParams.senderName && { senderName: customParams.senderName }),
+      ...(customParams.recipientName && {
+        recipientName: customParams.recipientName,
+      }),
+      ...(customParams.recipientIban && {
+        recipientIban: customParams.recipientIban,
+      }),
     };
 
     // {{account-srv}}/v1/admin/accounts/payout/trx
@@ -270,10 +329,16 @@ export function useDefaultAccountTransactions(customParams: IParams = {}) {
       // Any cleanup code can go here
     };
   }, [
-    customParams.date,
-    customParams.limit,
-    customParams.status,
-    customParams.page,
+    limit,
+    page,
+    date,
+    endDate,
+    status,
+    type,
+    recipientIban,
+    recipientName,
+    senderName,
+    not,
   ]);
 
   return { loading, transactions, meta, revalidate };
@@ -281,7 +346,7 @@ export function useDefaultAccountTransactions(customParams: IParams = {}) {
 
 export function usePayoutTransactions(customParams: IParams = {}) {
   const [transactions, setTransactions] = useState<TransactionType[]>([]);
-  const [meta, setMeta] = useState<BusinessTrxMeta | null>(null);
+  const [meta, setMeta] = useState<Meta | null>(null);
   const [loading, setLoading] = useState(true);
 
   const obj = useMemo(() => {


### PR DESCRIPTION
This pull request refactors the TransactionForAccount component to use meta data for default account transactions instead of calculating the values from the transactions array. This improves performance and reduces unnecessary calculations.