### PR TITLE
Refactor InquiryModal and PayoutDrawer components

### DIFF
--- a/src/app/(dashboard)/payouts/InquiryModal.tsx
+++ b/src/app/(dashboard)/payouts/InquiryModal.tsx
@@ -1,6 +1,7 @@
 import { closeButtonProps } from "@/app/admin/(dashboard)/businesses/[id]/(tabs)/utils";
 import { parseError } from "@/lib/actions/auth";
 import useNotification from "@/lib/hooks/notification";
+import Transaction from "@/lib/store/transaction";
 import { camelCaseToTitleCase } from "@/lib/utils";
 import { PrimaryBtn } from "@/ui/components/Buttons";
 import DropzoneComponent from "@/ui/components/Dropzone";
@@ -18,6 +19,7 @@ interface Props {
   type?: "recall" | "query" | "trace";
   pruneRef: string;
   trxId: string;
+  revalidate?: () => void;
 }
 
 export const InquiryModal = ({
@@ -26,9 +28,11 @@ export const InquiryModal = ({
   type,
   pruneRef,
   trxId,
+  revalidate,
 }: Props) => {
   const { handleError, handleSuccess, handleInfo } = useNotification();
   const { push } = useRouter();
+  const { close: closeTrxDrawer } = Transaction();
   const [processing, setProcessing] = useState(false);
   type FormValues = z.infer<typeof schema>;
 
@@ -63,9 +67,13 @@ export const InquiryModal = ({
         type === "query" ? "created" : "initiated"
       } a ${type}. Check under inquiries tab to  track the ${type} status.`;
 
-      push(`/payouts?tab=Inquiries`);
+      // push(`/payouts?tab=Inquiries`);
+      window.history.pushState({}, "", `/payouts?tab=Inquiries`);
+
+      revalidate && revalidate();
       handleSuccess(title, msg);
       close();
+      closeTrxDrawer();
       form.reset();
     } catch (error) {
       handleError("An error occurred", parseError(error));

--- a/src/app/(dashboard)/payouts/PayoutDrawer.tsx
+++ b/src/app/(dashboard)/payouts/PayoutDrawer.tsx
@@ -18,6 +18,7 @@ import {
 } from "@mantine/core";
 import {
   IconCircleArrowDown,
+  IconClockHour4,
   IconInfoCircleFilled,
   IconReload,
   IconReportSearch,
@@ -35,7 +36,7 @@ import {
   ReceiptDetails,
   TransactionReceipt,
 } from "@/ui/components/TransactionReceipt";
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { handlePdfDownload, parseError } from "@/lib/actions/auth";
 import { useSingleUserAccountByIBAN } from "@/lib/hooks/accounts";
 import { AmountGroup } from "@/ui/components/AmountGroup";
@@ -200,6 +201,22 @@ export const PayoutTransactionDrawer = ({
       setProcessing(false);
     }
   };
+
+  const { hasQuery, hasTrace, hasRecall } = useMemo(() => {
+    const hasQuery = Boolean(
+      data?.Inquiries?.find((inq) => inq.type === "QUERY")
+    );
+    const hasTrace = Boolean(
+      data?.Inquiries?.find((inq) => inq.type === "TRACE")
+    );
+    const hasRecall = Boolean(
+      data?.Inquiries?.find((inq) => inq.type === "RECALL")
+    );
+
+    return { hasQuery, hasTrace, hasRecall };
+  }, [data?.Inquiries]);
+
+  console.log(data);
 
   return (
     <Drawer
@@ -381,29 +398,32 @@ export const PayoutTransactionDrawer = ({
               <>
                 <SecondaryBtn
                   text="Query"
-                  icon={IconReportSearch}
+                  icon={hasQuery ? IconClockHour4 : IconReportSearch}
                   action={() => {
                     setInquiryType("query");
                     open();
                   }}
+                  disabled={hasQuery}
                 />
 
                 <SecondaryBtn
                   text="Run Trace"
-                  icon={IconReportSearch}
+                  icon={hasTrace ? IconClockHour4 : IconReportSearch}
                   action={() => {
                     setInquiryType("trace");
                     open();
                   }}
+                  disabled={hasTrace}
                 />
 
                 <SecondaryBtn
                   text="Recall"
-                  icon={IconReload}
+                  icon={hasRecall ? IconClockHour4 : IconReload}
                   action={() => {
                     setInquiryType("recall");
                     open();
                   }}
+                  disabled={hasRecall}
                 />
               </>
             )}
@@ -457,6 +477,7 @@ export const PayoutTransactionDrawer = ({
         close={closeModal}
         type={inquiryType}
         trxId={data?.id ?? ""}
+        revalidate={revalidate}
       />
 
       <ModalComponent

--- a/src/app/(dashboard)/payouts/page.tsx
+++ b/src/app/(dashboard)/payouts/page.tsx
@@ -7,7 +7,7 @@ import { IconCheck, IconInfoCircle } from "@tabler/icons-react";
 
 import { useSearchParams } from "next/navigation";
 
-import { Suspense, useRef, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { PrimaryBtn, SecondaryBtn } from "@/ui/components/Buttons";
 import useNotification from "@/lib/hooks/notification";
 import { parseError } from "@/lib/actions/auth";
@@ -23,11 +23,13 @@ import { LiveDateModal } from "../settings/LiveDateModal";
 import { AlertStore } from "@/lib/store/alert";
 import { PayoutTransactions } from "./(tabs)/PayoutTransactions";
 import PayoutRequests from "./(tabs)/Requests";
+import { set } from "zod";
 
 function PayoutTrx() {
   const searchParams = useSearchParams();
 
   const { tab } = Object.fromEntries(searchParams.entries());
+  const [tabValue, setTabValue] = useState<string | null>(tab);
 
   const [processing, setProcessing] = useState(false);
   const [liveDate, setLiveDate] = useState<Date | null>(null);
@@ -39,6 +41,10 @@ function PayoutTrx() {
 
   const { business, meta, revalidate, loading } = useUserBusiness();
   const { close: closeAlert, opened: openedAlert } = AlertStore();
+
+  useEffect(() => {
+    setTabValue(tab);
+  }, [tab]);
 
   const requestPayoutAccount = async () => {
     setProcessing(true);
@@ -170,7 +176,12 @@ function PayoutTrx() {
       </Group>
 
       <TabsComponent
-        defaultValue={tabs.find((t) => t.value === tab)?.value ?? tabs[0].value}
+        // defaultValue={tabs.find((t) => t.value === tab)?.value ?? tabs[0].value}
+        value={tabValue}
+        onChange={(value) => {
+          setTabValue(value);
+          window.history.pushState({}, "", `?tab=${value}`);
+        }}
         tabs={tabs}
         mt={28}
         keepMounted={false}

--- a/src/lib/hooks/transactions.ts
+++ b/src/lib/hooks/transactions.ts
@@ -815,6 +815,11 @@ export interface Meta {
   totalAmount: number;
 }
 
+export interface Inquiry {
+  id: string;
+  type: "QUERY" | "RECALL" | "TRACE";
+}
+
 export interface TransactionType {
   id: string;
   senderIban: string;
@@ -837,4 +842,5 @@ export interface TransactionType {
   type: "DEBIT" | "CREDIT";
   company: BusinessData;
   narration?: string;
+  Inquiries?: Inquiry[];
 }


### PR DESCRIPTION
This pull request refactors the InquiryModal and PayoutDrawer components in the payouts directory. The InquiryModal component is updated to include a new import statement for the Transaction module and the revalidate prop. The push function is also updated to use window.history.pushState instead of push from useRouter. The PayoutDrawer component is updated to include a new import statement for IconClockHour4 and to conditionally disable the SecondaryBtn components based on the values of hasQuery, hasTrace, and hasRecall. No breaking changes are introduced in this commit.