### PR TITLE
Refactor user table in dashboard to add reset password modal for confirmation

### DIFF
--- a/src/app/admin/(dashboard)/users/[id]/business/[userId]/page.tsx
+++ b/src/app/admin/(dashboard)/users/[id]/business/[userId]/page.tsx
@@ -23,7 +23,13 @@ import { BadgeComponent } from "@/ui/components/Badge";
 import { useSingleBusiness } from "@/lib/hooks/businesses";
 import ModalComponent from "@/ui/components/Modal";
 import UpdateModal from "../../../modal";
-import { IconPencilMinus, IconUserCheck, IconUserX } from "@tabler/icons-react";
+import {
+  IconFileUnknown,
+  IconFilterQuestion,
+  IconPencilMinus,
+  IconUserCheck,
+  IconUserX,
+} from "@tabler/icons-react";
 import { useDisclosure } from "@mantine/hooks";
 import { useState } from "react";
 import { useForm, zodResolver } from "@mantine/form";
@@ -37,6 +43,8 @@ export default function SingleUser() {
   const [deactivateOpened, { open: openDeactivate, close: closeDeactivate }] =
     useDisclosure(false);
   const [updateOpened, { open: openUpdate, close: closeUpdate }] =
+    useDisclosure(false);
+  const [resetOpened, { open: openReset, close: closeReset }] =
     useDisclosure(false);
   const [processing, setProcessing] = useState(false);
   const [reason, setReason] = useState("");
@@ -94,8 +102,8 @@ export default function SingleUser() {
             <Group>
               {!loading ? (
                 <Text fz={24} fw={600} c="var(--prune-text-gray-700)">
-                  {`${user?.firstName ?? "First Name Here"} ${
-                    user?.lastName ?? "Last Name Here"
+                  {`${user?.firstName ?? "Gabriela"} ${
+                    user?.lastName ?? "Anyiam"
                   }`}
                 </Text>
               ) : (
@@ -114,7 +122,7 @@ export default function SingleUser() {
           </Stack>
 
           <Group>
-            <SecondaryBtn text="Reset Password" fw={600} />
+            <SecondaryBtn text="Reset Password" fw={600} action={openReset} />
             <PrimaryBtn
               text={user?.status === "ACTIVE" ? "Deactivate" : "Activate"}
               fw={600}
@@ -215,6 +223,20 @@ export default function SingleUser() {
         customApproveMessage={`Yes, ${
           user?.status === "ACTIVE" ? "Deactivate" : "Activate"
         }`}
+      />
+
+      <ModalComponent
+        opened={resetOpened}
+        close={closeReset}
+        title="Are you sure you want send a reset password link"
+        text={`You will be sending a reset password link to ${
+          user?.email ?? ""
+        } to reset their password`}
+        customApproveMessage="Yes, Send"
+        icon={<IconFileUnknown color="#C6A700" />}
+        color="#F9F6E6"
+        processing={processing}
+        action={() => {}}
       />
 
       {/* Update Details Modal */}

--- a/src/app/admin/(dashboard)/users/[id]/business/[userId]/page.tsx
+++ b/src/app/admin/(dashboard)/users/[id]/business/[userId]/page.tsx
@@ -17,7 +17,7 @@ import {
 
 import dayjs from "dayjs";
 import advancedFormat from "dayjs/plugin/advancedFormat";
-import { useSingleAdmin } from "@/lib/hooks/admins";
+import { useSingleAdmin, useSingleBusinessUser } from "@/lib/hooks/admins";
 import { BackBtn, PrimaryBtn, SecondaryBtn } from "@/ui/components/Buttons";
 import { BadgeComponent } from "@/ui/components/Badge";
 import { useSingleBusiness } from "@/lib/hooks/businesses";
@@ -49,7 +49,10 @@ export default function SingleUser() {
   const [processing, setProcessing] = useState(false);
   const [reason, setReason] = useState("");
 
-  const { user, loading, revalidate } = useSingleAdmin(params.userId);
+  const { user, loading, revalidate } = useSingleBusinessUser(
+    params.id,
+    params.userId
+  );
   const { business, loading: loadingBiz } = useSingleBusiness(params.id);
 
   const form = useForm<typeof newAdmin>({

--- a/src/app/admin/(dashboard)/users/[id]/business/page.tsx
+++ b/src/app/admin/(dashboard)/users/[id]/business/page.tsx
@@ -91,7 +91,7 @@ export default function AllBusinessUsers() {
         <TableTd>{"User"}</TableTd>
         <TableTd>{dayjs(element.createdAt).format("ddd DD MMM YYYY")}</TableTd>
         <TableTd>
-          {element.lastLogIn ? dayjs(element.lastLogIn).fromNow() : "Nil"}
+          {element.lastLogin ? dayjs(element.lastLogin).fromNow() : "Nil"}
         </TableTd>
 
         <TableTd>

--- a/src/lib/hooks/admins.ts
+++ b/src/lib/hooks/admins.ts
@@ -149,6 +149,40 @@ export function useBusinessUsers(customParams: IParams = {}, id: string) {
   return { loading, users, revalidate, meta };
 }
 
+export function useSingleBusinessUser(businessId: string, userId: string) {
+  const [user, setUser] = useState<AdminData>();
+
+  const [loading, setLoading] = useState(true);
+
+  async function fetchUsers() {
+    setLoading(true);
+    try {
+      const { data } = await axios.get(
+        `${process.env.NEXT_PUBLIC_SERVER_URL}/admin/businesses/${businessId}/users/${userId}`,
+        { headers: { Authorization: `Bearer ${Cookies.get("auth")}` } }
+      );
+
+      setUser(data.data);
+    } catch (error) {
+      console.log(error);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const revalidate = () => fetchUsers();
+
+  useEffect(() => {
+    fetchUsers();
+
+    return () => {
+      // Any cleanup code can go here
+    };
+  }, []);
+
+  return { loading, user, revalidate };
+}
+
 export function useUsers(customParams: IParams = {}) {
   const [users, setUsers] = useState<AdminData[]>([]);
   const [meta, setMeta] = useState<{ total: number }>();

--- a/src/lib/hooks/admins.ts
+++ b/src/lib/hooks/admins.ts
@@ -245,6 +245,7 @@ export interface AdminData {
   firstName: string;
   lastName: string;
   role: string;
+  lastLogin: Date | null;
   lastLogIn: Date | null;
   status: "ACTIVE" | "INACTIVE" | "INVITE_PENDING";
 }


### PR DESCRIPTION
This pull request refactors the user table in the dashboard to add a reset password modal for confirmation. It also includes changes to use the `useSingleBusinessUser` hook to fetch business user data and handle null values for the last login time. Additionally, a new `useSingleBusinessUser` hook is added to fetch a single business user.