### PR TITLE
Refactor Account and CardTwo components for improved usability and customization

### DIFF
--- a/src/app/(dashboard)/accounts/[id]/page.tsx
+++ b/src/app/(dashboard)/accounts/[id]/page.tsx
@@ -283,7 +283,6 @@ export default function Account() {
           limit={limit}
           total={Math.ceil((txrMeta?.total ?? 0) / parseInt(limit ?? "10", 10))}
         />
-        <Text>Pagination here</Text>
       </SingleAccountBody>
 
       <Modal

--- a/src/ui/components/Cards/AccountCard.tsx
+++ b/src/ui/components/Cards/AccountCard.tsx
@@ -155,7 +155,7 @@ export const AccountCard = ({
       >
         {link && (
           <Link href={link}>
-            <SeeAll name="See More" />
+            <SeeAll name="See More" fontSize={14} />
           </Link>
         )}
       </Group>

--- a/src/ui/components/Cards/index.tsx
+++ b/src/ui/components/Cards/index.tsx
@@ -40,10 +40,16 @@ interface ICardOne {
   btnLink?: string;
 }
 
-export const SeeAll = ({ name = "See All" }: { name?: string }) => {
+export const SeeAll = ({
+  name = "See All",
+  fontSize = 12,
+}: {
+  name?: string;
+  fontSize?: number;
+}) => {
   return (
     <div className={styles.card__link}>
-      <Text fz={14} td="underline" fw={600}>
+      <Text fz={fontSize} td="underline" fw={600}>
         {name}
       </Text>
       <IconChevronRight size={16} />

--- a/src/ui/components/Cards/index.tsx
+++ b/src/ui/components/Cards/index.tsx
@@ -19,7 +19,7 @@ import {
 } from "@tabler/icons-react";
 
 import styles from "./styles.module.scss";
-import { approvedBadgeColor, formatNumber } from "@/lib/utils";
+import { approvedBadgeColor, formatNumber, getInitials } from "@/lib/utils";
 import dayjs from "dayjs";
 
 import EmptyImage from "@/assets/empty.png";
@@ -220,10 +220,7 @@ export function CardTwo({ title, link, items }: ICardTwo) {
                       placeholder: { color: "var(--prune-text-gray-700)" },
                     }}
                   >
-                    {item.title
-                      .split(" ")
-                      .map((item) => item.charAt(0))
-                      .join("")}
+                    {getInitials(item.title)}
                   </Avatar>
                   <Text fz={12} fw={600} className={styles.header__text}>
                     {item.title}


### PR DESCRIPTION
Remove unnecessary pagination text in the Account component, add a fontSize prop to the SeeAll component for customizable text size, and replace manual initials generation with a utility function in the CardTwo component.