### PR TITLE
Made some refactor to enable switching from LIVE to TEST.

### DIFF
--- a/src/app/(dashboard)/payouts/(tabs)/Requests/PendingRequests.tsx
+++ b/src/app/(dashboard)/payouts/(tabs)/Requests/PendingRequests.tsx
@@ -194,23 +194,7 @@ export const PendingPayoutRequests = () => {
         selectedRequest={data}
         opened={opened}
         close={close}
-      >
-        <Group justify="end" pr={28} mt={20}>
-          <SecondaryBtn
-            icon={IconX}
-            text="Reject"
-            fw={600}
-            action={openReject}
-          />
-
-          <PrimaryBtn
-            icon={IconCheck}
-            text="Approve"
-            fw={600}
-            action={openApprove}
-          />
-        </Group>
-      </PayoutTransactionRequestDrawer>
+      />
 
       <ModalComponent
         color="#FEF3F2"

--- a/src/app/(dashboard)/payouts/PayoutDrawer.tsx
+++ b/src/app/(dashboard)/payouts/PayoutDrawer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   TransactionType,
   useSingleCompanyTransactions,
@@ -66,7 +68,8 @@ export const PayoutTransactionDrawer = ({
   const [openedCancel, { open: openCancel, close: closeCancel }] =
     useDisclosure(false);
   const axios = createAxiosInstance("payouts");
-  const stage = localStorage.getItem("stage");
+  const stage =
+    typeof window !== "undefined" ? window.localStorage.getItem("stage") : "";
 
   const [inquiryType, setInquiryType] = useState<
     "recall" | "query" | "trace"

--- a/src/app/(dashboard)/payouts/PayoutDrawer.tsx
+++ b/src/app/(dashboard)/payouts/PayoutDrawer.tsx
@@ -66,6 +66,7 @@ export const PayoutTransactionDrawer = ({
   const [openedCancel, { open: openCancel, close: closeCancel }] =
     useDisclosure(false);
   const axios = createAxiosInstance("payouts");
+  const stage = localStorage.getItem("stage");
 
   const [inquiryType, setInquiryType] = useState<
     "recall" | "query" | "trace"
@@ -389,7 +390,7 @@ export const PayoutTransactionDrawer = ({
                 data.status === "PENDING") && (
                 <></> */}
 
-        {!isAdmin && (
+        {!isAdmin && stage === "LIVE" && (
           <Flex wrap="nowrap" gap={10} justify="space-between" mt={20} mr={28}>
             {data && data.status === "CONFIRMED" && (
               <>
@@ -441,11 +442,6 @@ export const PayoutTransactionDrawer = ({
                 text={`Download ${
                   data?.status === "CANCELLED" ? "Receipt" : ""
                 }`}
-                // text={`Download ${
-                //   !isAfter24Hours(data?.createdAt ?? new Date())
-                //     ? "Receipt"
-                //     : ""
-                // }`}
                 fullWidth={data?.status === "CANCELLED"}
                 // fullWidth={!isAfter24Hours(data?.createdAt ?? new Date())}
                 fw={600}

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -15,7 +15,10 @@ const createAxiosInstance = (baseURL: keyof typeof BASEURL) => {
   axiosInstance.interceptors.request.use(
     (config) => {
       const token = Cookies.get("auth");
-      const stage = localStorage.getItem("stage") || "TEST";
+      const stage =
+        typeof window !== "undefined"
+          ? window.localStorage.getItem("stage") || "TEST"
+          : "TEST";
 
       if (token) {
         config.headers.Authorization = `Bearer ${token}`;

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -15,7 +15,7 @@ const createAxiosInstance = (baseURL: keyof typeof BASEURL) => {
   axiosInstance.interceptors.request.use(
     (config) => {
       const token = Cookies.get("auth");
-      const stage = localStorage.getItem("stage") || "test";
+      const stage = localStorage.getItem("stage") || "TEST";
 
       if (token) {
         config.headers.Authorization = `Bearer ${token}`;

--- a/src/lib/hooks/requests.ts
+++ b/src/lib/hooks/requests.ts
@@ -476,9 +476,12 @@ export function useUserRequests(customParams: IParams = {}) {
 
     setLoading(true);
     try {
-      const { data } = await acctAxiosInstance.get(`/admin/requests/all`, {
-        params,
-      });
+      const { data } = await acctAxiosInstance.get(
+        `/accounts/dashboard/requests`,
+        {
+          params,
+        }
+      );
 
       setMeta(data.meta);
       setRequests(data.data);

--- a/src/ui/components/Header/index.tsx
+++ b/src/ui/components/Header/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Divider,
   TextInput,
@@ -251,7 +253,10 @@ export function UserHeader() {
   const { setMeta } = NotificationStore();
   const { refresh } = useRouter();
 
-  const _stage = localStorage.getItem("stage");
+  const _stage =
+    typeof window !== "undefined"
+      ? window.localStorage.getItem("stage")
+      : "TEST";
   const [stage, setStage] = useState(_stage ?? "TEST");
 
   const { loading, notifications, meta, revalidate } = useUserNotifications({

--- a/src/ui/components/Header/index.tsx
+++ b/src/ui/components/Header/index.tsx
@@ -43,6 +43,7 @@ import useNotification from "@/lib/hooks/notification";
 import { parseError } from "@/lib/actions/auth";
 import EmptyTable from "../EmptyTable";
 import { NotificationStore } from "@/lib/store/notification";
+import { useRouter } from "next/navigation";
 
 export default function Header() {
   const { user, setUser } = User();
@@ -248,6 +249,10 @@ export function UserHeader() {
   const [opened, setOpened] = useState(false);
   const [processing, setProcessing] = useState(false);
   const { setMeta } = NotificationStore();
+  const { refresh } = useRouter();
+
+  const _stage = localStorage.getItem("stage");
+  const [stage, setStage] = useState(_stage ?? "TEST");
 
   const { loading, notifications, meta, revalidate } = useUserNotifications({
     status: "unread",
@@ -313,8 +318,6 @@ export function UserHeader() {
     }
   }, [user]);
 
-  const [stage, setStage] = useState("live");
-
   const searchIcon = <IconSearch style={{ width: 20, height: 20 }} />;
   return (
     <header className={styles.header}>
@@ -327,15 +330,6 @@ export function UserHeader() {
         />
       </div>
 
-      {/* <div className={styles.stage__trigger}>
-        <Text
-          fz={14}
-          fw={500}
-          tt="capitalize"
-          c={stage === "live" ? "green" : "dimmed"}
-        >
-          {stage} Mode
-        </Text> */}
       <Switch
         color="green"
         c={stage === "LIVE" ? "green" : "dimmed"}
@@ -345,15 +339,16 @@ export function UserHeader() {
         defaultChecked={stage === "LIVE"}
         size="xs"
         tt="capitalize"
-        label={`${stage.toLowerCase()} Mode`}
+        label={`${(stage ?? "test").toLowerCase()} Mode`}
         styles={{ label: { fontSize: 14 } }}
         onChange={(event) => {
           const newStage = event.currentTarget.checked ? "LIVE" : "TEST";
           setStage(newStage);
           localStorage.setItem("stage", newStage);
+          // window.location.reload();
+          refresh();
         }}
       />
-      {/* </div> */}
 
       <div className={styles.notification}>
         <Divider orientation="vertical" h={26} />


### PR DESCRIPTION
This pull request includes changes to the payout request handling and user interface components. The changes mainly focus on improving the handling of the "stage" environment variable, refining the user interface, and updating API endpoints.

### Handling of "stage" environment variable:

* [`src/app/(dashboard)/payouts/PayoutDrawer.tsx`](diffhunk://#diff-dee75178fed34c12e5e1559cf7de5f55b71948cf1670b63e6b07b9730d569c0bR69): Added the retrieval of the "stage" variable from local storage and adjusted the conditional rendering to include the "LIVE" stage check. [[1]](diffhunk://#diff-dee75178fed34c12e5e1559cf7de5f55b71948cf1670b63e6b07b9730d569c0bR69) [[2]](diffhunk://#diff-dee75178fed34c12e5e1559cf7de5f55b71948cf1670b63e6b07b9730d569c0bL392-R393)
* [`src/lib/axios.ts`](diffhunk://#diff-bfdb8aa3cd43a7af613c63ac93c06d0d320aa32aa153d3fdaf13db4d6a453f68L18-R18): Changed the default value of the "stage" variable to "TEST" when not found in local storage.

### User Interface Updates:

* [`src/app/(dashboard)/payouts/(tabs)/Requests/PendingRequests.tsx`](diffhunk://#diff-5b2fafab9c0230f4a3ca59a5f7aec84ebd200d67aeca5964f14447e2ea420689L197-L214): Removed the reject and approve buttons from the `PayoutTransactionRequestDrawer` component.
* [`src/ui/components/Header/index.tsx`](diffhunk://#diff-0e2bbe145f13064b0453b83bedc133690e4ee5040c697289e0aa7aa9df579265R46): Added the use of the `useRouter` hook for refreshing the page and updated the stage switch to reflect the current stage from local storage. [[1]](diffhunk://#diff-0e2bbe145f13064b0453b83bedc133690e4ee5040c697289e0aa7aa9df579265R46) [[2]](diffhunk://#diff-0e2bbe145f13064b0453b83bedc133690e4ee5040c697289e0aa7aa9df579265R252-R255) [[3]](diffhunk://#diff-0e2bbe145f13064b0453b83bedc133690e4ee5040c697289e0aa7aa9df579265L348-L356)

### API Endpoint Update:

* [`src/lib/hooks/requests.ts`](diffhunk://#diff-06f058c2658fdce65ac9262a68243e7b90c935a9f48e2452ceed3f25949664e8L479-R484): Updated the API endpoint for fetching user requests to `/accounts/dashboard/requests`.