### PR TITLE
Add stage toggle switch to Header component and clean up sendMoneyMod…

### DIFF
--- a/src/ui/components/Header/index.tsx
+++ b/src/ui/components/Header/index.tsx
@@ -56,6 +56,12 @@ export default function Header() {
   const [processing, setProcessing] = useState(false);
   const { setMeta } = NotificationStore();
 
+  const _stage =
+    typeof window !== "undefined"
+      ? window.localStorage.getItem("stage")
+      : "TEST";
+  const [stage, setStage] = useState(_stage ?? "TEST");
+
   const { loading, notifications, meta, revalidate } = useAdminNotifications({
     status: "unread",
     limit: 4,
@@ -131,6 +137,27 @@ export default function Header() {
           classNames={{ wrapper: styles.search__input, input: styles.input }}
         />
       </div>
+
+      <Switch
+        color="green"
+        c={stage === "LIVE" ? "green" : "dimmed"}
+        fz={14}
+        fw={500}
+        labelPosition="left"
+        checked={stage === "LIVE"}
+        // defaultChecked={stage === "LIVE"}
+        size="xs"
+        tt="capitalize"
+        label={`${(stage ?? "test").toLowerCase()} Mode`}
+        styles={{ label: { fontSize: 14 } }}
+        onChange={(event) => {
+          const newStage = event.currentTarget.checked ? "LIVE" : "TEST";
+
+          setStage(newStage);
+          localStorage.setItem("stage", newStage);
+          window.location.reload();
+        }}
+      />
 
       <div className={styles.notification}>
         <Divider orientation="vertical" h={26} />

--- a/src/ui/components/SingleAccount/sendMoneyModal.tsx
+++ b/src/ui/components/SingleAccount/sendMoneyModal.tsx
@@ -1,16 +1,7 @@
 "use client";
-import Cookies from "js-cookie";
 
-import axios from "axios";
-import { Fragment, useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
-import {
-  IconArrowLeft,
-  IconExclamationMark,
-  IconPlus,
-  IconX,
-} from "@tabler/icons-react";
-
+import { useState } from "react";
+import { IconExclamationMark, IconX } from "@tabler/icons-react";
 import styles from "./sendMoney.module.scss";
 
 import {
@@ -19,22 +10,16 @@ import {
   ThemeIcon,
   Text,
   Box,
-  NumberInput,
-  Textarea,
   Stack,
   Group,
   Alert,
 } from "@mantine/core";
-import { TextInput, Select, Button, UnstyledButton } from "@mantine/core";
-import { useForm, zodResolver } from "@mantine/form";
-import { PrimaryBtn, SecondaryBtn } from "../Buttons";
+import { PrimaryBtn } from "../Buttons";
 import { formatNumber } from "@/lib/utils";
-import { DefaultAccount, validateAccount } from "@/lib/hooks/accounts";
-import DropzoneComponent from "../Modal/dropzone";
+import { DefaultAccount } from "@/lib/hooks/accounts";
 import TabsComponent from "../Tabs";
 import Individual from "./Individual";
 import Company from "./company";
-import { set } from "zod";
 
 interface SendMoneyModalProps {
   account: DefaultAccount | null;


### PR DESCRIPTION
This pull request includes changes to the `Header` component to add a new switch for toggling between "LIVE" and "TEST" modes, and refactors the `sendMoneyModal` component by removing unused imports and dependencies.

Changes to `Header` component:

* Added a new state variable `stage` to manage the mode ("LIVE" or "TEST") and initialized it from local storage. (`src/ui/components/Header/index.tsx`, [src/ui/components/Header/index.tsxR59-R64](diffhunk://#diff-0e2bbe145f13064b0453b83bedc133690e4ee5040c697289e0aa7aa9df579265R59-R64))
* Added a `Switch` component to toggle between "LIVE" and "TEST" modes, updating the `stage` state and local storage accordingly, and reloading the page on change. (`src/ui/components/Header/index.tsx`, [src/ui/components/Header/index.tsxR141-R161](diffhunk://#diff-0e2bbe145f13064b0453b83bedc133690e4ee5040c697289e0aa7aa9df579265R141-R161))

Refactoring in `sendMoneyModal` component:

* Removed unused imports such as `Cookies`, `axios`, and several icons. (`src/ui/components/SingleAccount/sendMoneyModal.tsx`, [src/ui/components/SingleAccount/sendMoneyModal.tsxL2-R4](diffhunk://#diff-2f6d6a3093f005ec84f17a1718e4134d538a3dd8aea1b9d4f213c04850714ce0L2-R4))
* Cleaned imports by removing unused components from `@mantine/core` and other modules. (`src/ui/components/SingleAccount/sendMoneyModal.tsx`, [src/ui/components/SingleAccount/sendMoneyModal.tsxL22-L37](diffhunk://#diff-2f6d6a3093f005ec84f17a1718e4134d538a3dd8aea1b9d4f213c04850714ce0L22-L37))