### PR TITLE
Forgot password and reset password for admin

### DIFF
--- a/src/app/auth/admin/forgot-password/page.tsx
+++ b/src/app/auth/admin/forgot-password/page.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { Box, Paper, Text, TextInput } from "@mantine/core";
+import Image from "next/image";
+import PruneIcon from "@/assets/icon.png";
+import styles from "./style.module.scss";
+import { inter } from "@/ui/fonts";
+import { PrimaryBtn } from "@/ui/components/Buttons";
+import { useForm, zodResolver } from "@mantine/form";
+import { z } from "zod";
+import { useState } from "react";
+import useNotification from "@/lib/hooks/notification";
+import { parseError } from "@/lib/actions/auth";
+import axios from "axios";
+import { useRouter } from "next/navigation";
+
+export default function UserForgotPassword() {
+  const [processing, setProcessing] = useState(false);
+  const { handleError, handleSuccess } = useNotification();
+  const { push } = useRouter();
+
+  const schema = z.object({
+    email: z.string().email("Invalid Email").min(1, "Email is required"),
+  });
+  const form = useForm({
+    initialValues: { email: "" },
+    validate: zodResolver(schema),
+  });
+
+  const handleResetLink = async () => {
+    setProcessing(true);
+    try {
+      await axios.post(
+        `${process.env.NEXT_PUBLIC_SERVER_URL}/auth/forgot-password`,
+        { ...form.values }
+      );
+      handleSuccess(
+        "Email Sent",
+        `A password reset link has been sent to your email. `
+      );
+      push("/auth/reset-password");
+    } catch (error) {
+      handleError("Sending Reset Link Failed", parseError(error));
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <Paper w={476} className={styles.paper}>
+        <Image width={29} height={29} src={PruneIcon} alt="prune icon" />
+        <Text c="var(--prune-text-gray-900)" fz={24} fw={600} mt={27} mb={0}>
+          Forgot Password
+        </Text>
+        <Text
+          fz={14}
+          fw={400}
+          m={0}
+          p={0}
+          c="var(--prune-text-gray-600)"
+          style={{ fontFamily: inter.style.fontFamily }}
+        >
+          Do not worry, we would help you reset it.
+        </Text>
+
+        <Box
+          component="form"
+          onSubmit={form.onSubmit(() => handleResetLink())}
+          w="100%"
+        >
+          <TextInput
+            mt={42}
+            placeholder="Enter Email"
+            {...form.getInputProps("email")}
+            classNames={{ input: styles.input }}
+          />
+
+          <PrimaryBtn
+            text="Send Reset Link"
+            fullWidth
+            mt={39}
+            fw={600}
+            type="submit"
+            loading={processing}
+          />
+        </Box>
+
+        <PrimaryBtn
+          text="Go back to Login"
+          link="/auth/admin/login"
+          mt={10}
+          td="underline"
+          variant="transparent"
+          c="var(--prune-primary-700)"
+          fz={14}
+          fw={600}
+        />
+      </Paper>
+    </div>
+  );
+}

--- a/src/app/auth/admin/forgot-password/page.tsx
+++ b/src/app/auth/admin/forgot-password/page.tsx
@@ -31,14 +31,14 @@ export default function UserForgotPassword() {
     setProcessing(true);
     try {
       await axios.post(
-        `${process.env.NEXT_PUBLIC_SERVER_URL}/auth/forgot-password`,
+        `${process.env.NEXT_PUBLIC_SERVER_URL}/admin/forgot-password`,
         { ...form.values }
       );
       handleSuccess(
         "Email Sent",
         `A password reset link has been sent to your email. `
       );
-      push("/auth/reset-password");
+      push("/auth/admin/reset-password");
     } catch (error) {
       handleError("Sending Reset Link Failed", parseError(error));
     } finally {

--- a/src/app/auth/admin/forgot-password/style.module.scss
+++ b/src/app/auth/admin/forgot-password/style.module.scss
@@ -1,0 +1,17 @@
+.container {
+  max-height: 100svh;
+  height: 100svh;
+  display: grid;
+  place-items: center;
+
+  .paper {
+    padding: 40px 37px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    // .input:focus {
+    //   border: 1px solid var(--prune-primary-700);
+    // }
+  }
+}

--- a/src/app/auth/admin/login/form.tsx
+++ b/src/app/auth/admin/login/form.tsx
@@ -114,6 +114,7 @@ function LoginForm() {
         p={0}
         c="var(--prune-primary-800)"
         td="underline"
+        link="/auth/admin/forgot-password"
       />
     </Box>
   );

--- a/src/app/auth/admin/reset-password/page.tsx
+++ b/src/app/auth/admin/reset-password/page.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import {
+  Box,
+  Paper,
+  PasswordInput,
+  PinInput,
+  Stack,
+  Text,
+  TextInput,
+} from "@mantine/core";
+import Image from "next/image";
+import PruneIcon from "@/assets/icon.png";
+import styles from "./style.module.scss";
+import { inter } from "@/ui/fonts";
+import { PrimaryBtn } from "@/ui/components/Buttons";
+import { useForm, zodResolver } from "@mantine/form";
+import {
+  resetPasswordSchema,
+  ResetPasswordType,
+  resetPasswordValues,
+} from "@/lib/schema";
+import { useRouter, useSearchParams } from "next/navigation";
+import useNotification from "@/lib/hooks/notification";
+import { Suspense, useState } from "react";
+import { parseError } from "@/lib/actions/auth";
+import axios from "axios";
+
+function UserForgotPassword() {
+  const [processing, setProcessing] = useState(false);
+  const { handleError, handleSuccess } = useNotification();
+  const { push } = useRouter();
+
+  const searchParams = useSearchParams();
+  const code = searchParams.get("code") ?? "";
+  const form = useForm<ResetPasswordType>({
+    initialValues: { ...resetPasswordValues, otp: code },
+    validate: zodResolver(resetPasswordSchema),
+  });
+
+  const handleResetPassword = async () => {
+    setProcessing(true);
+    const { otp, password } = form.values;
+    try {
+      await axios.post(
+        `${process.env.NEXT_PUBLIC_SERVER_URL}/auth/reset-password`,
+        { token: Number(otp), password }
+      );
+      handleSuccess(
+        "Successful! Password Reset",
+        "Your password has been changed successfully"
+      );
+      push("/auth/login");
+    } catch (error) {
+      handleError("Password Reset Failed", parseError(error));
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <Paper w={476} className={styles.paper}>
+        <Image width={29} height={29} src={PruneIcon} alt="prune icon" />
+        <Text c="var(--prune-text-gray-900)" fz={24} fw={600} mt={27} mb={0}>
+          Reset Password
+        </Text>
+        <Text
+          fz={14}
+          fw={400}
+          m={0}
+          p={0}
+          c="var(--prune-text-gray-600)"
+          style={{ fontFamily: inter.style.fontFamily }}
+        >
+          Create a new password.
+        </Text>
+
+        <Box
+          component="form"
+          onSubmit={form.onSubmit(() => handleResetPassword())}
+          w="100%"
+        >
+          <PasswordInput
+            mt={42}
+            placeholder="Enter New Password"
+            {...form.getInputProps("password")}
+            classNames={{ input: styles.input }}
+          />
+
+          <PasswordInput
+            mt={42}
+            placeholder="Confirm New Password"
+            {...form.getInputProps("confirmPassword")}
+            classNames={{ input: styles.input }}
+          />
+
+          <Stack gap={3}>
+            <PinInput
+              oneTimeCode
+              {...form.getInputProps("otp")}
+              mt={30}
+              type="number"
+              length={6}
+              error={!!form.errors.otp}
+            />
+
+            {!!form.errors.otp && (
+              <Text fz={12} c="var(--prune-warning)">
+                {form.errors && form.errors.otp}
+              </Text>
+            )}
+          </Stack>
+
+          <PrimaryBtn
+            text="Reset Password"
+            fullWidth
+            mt={39}
+            fw={600}
+            type="submit"
+            loading={processing}
+          />
+        </Box>
+
+        <PrimaryBtn
+          text="Go back to Login"
+          link="/auth/login"
+          mt={10}
+          td="underline"
+          variant="transparent"
+          c="var(--prune-primary-700)"
+          fz={14}
+          fw={600}
+        />
+      </Paper>
+    </div>
+  );
+}
+
+export default function UserForgotPasswordSuspense() {
+  return (
+    <Suspense>
+      <UserForgotPassword />
+    </Suspense>
+  );
+}

--- a/src/app/auth/admin/reset-password/page.tsx
+++ b/src/app/auth/admin/reset-password/page.tsx
@@ -43,14 +43,14 @@ function UserForgotPassword() {
     const { otp, password } = form.values;
     try {
       await axios.post(
-        `${process.env.NEXT_PUBLIC_SERVER_URL}/auth/reset-password`,
+        `${process.env.NEXT_PUBLIC_SERVER_URL}/admin/reset-password`,
         { token: Number(otp), password }
       );
       handleSuccess(
         "Successful! Password Reset",
         "Your password has been changed successfully"
       );
-      push("/auth/login");
+      push("/auth/admin/login");
     } catch (error) {
       handleError("Password Reset Failed", parseError(error));
     } finally {

--- a/src/app/auth/admin/reset-password/style.module.scss
+++ b/src/app/auth/admin/reset-password/style.module.scss
@@ -1,0 +1,17 @@
+.container {
+  max-height: 100svh;
+  height: 100svh;
+  display: grid;
+  place-items: center;
+
+  .paper {
+    padding: 40px 37px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    // .input:focus {
+    //   border: 1px solid var(--prune-primary-700);
+    // }
+  }
+}


### PR DESCRIPTION
This pull request introduces new functionality for the forgot password and reset password processes in the admin authentication flow. The most important changes include adding new pages for forgot and reset passwords, updating the login form to include a link to the forgot password page, and adding corresponding styles.

New functionality:

* [`src/app/auth/admin/forgot-password/page.tsx`](diffhunk://#diff-8bd606d35d12feae3de1d464ab62cf0eb9d4eb7e5b7b43ef4e868811eff4f334R1-R102): Added a new `UserForgotPassword` component that allows users to request a password reset link by entering their email. This component includes form validation, API calls to send the reset link, and notification handling.
* [`src/app/auth/admin/reset-password/page.tsx`](diffhunk://#diff-71c428bca0b254d235d72b2a8a549f0fe228778030ec47d453091ea8022cf196R1-R146): Added a new `UserForgotPasswordSuspense` component that allows users to reset their password by entering a new password and a verification code. This component includes form validation, API calls to reset the password, and notification handling.

Style updates:

* [`src/app/auth/admin/forgot-password/style.module.scss`](diffhunk://#diff-6681621fdc90f663c9d6d4897c88993ec9bf29cbf6f4fee57676cb8fa25613b8R1-R17): Added styles for the forgot password page, including container and paper styles.
* [`src/app/auth/admin/reset-password/style.module.scss`](diffhunk://#diff-6681621fdc90f663c9d6d4897c88993ec9bf29cbf6f4fee57676cb8fa25613b8R1-R17): Added styles for the reset password page, including container and paper styles.

Login form update:

* [`src/app/auth/admin/login/form.tsx`](diffhunk://#diff-80cec5b1282070cad8a35efbcb5d61855d1a857a07d16a703635f21575ed3e88R117): Updated the login form to include a link to the forgot password page.