### PR TITLE
Refactor to improve error messaging when adding new director or shareholder

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -417,8 +417,12 @@ export const validateNewBusiness = z.object({
           },
           { message: "Invalid director's email" }
         ),
-        identityType: z.string().nullable(),
-        proofOfAddress: z.string().nullable(),
+        identityType: z
+          .string({ invalid_type_error: "Identity Type is required" })
+          .nullable(),
+        proofOfAddress: z
+          .string({ invalid_type_error: "Proof of Address is required" })
+          .nullable(),
         identityFileUrl: z.string(),
         identityFileUrlBack: z.string(),
         proofOfAddressFileUrl: z.string(),
@@ -436,8 +440,12 @@ export const validateNewBusiness = z.object({
         },
         { message: "Invalid shareholder's email" }
       ),
-      identityType: z.string().nullable(),
-      proofOfAddress: z.string().nullable(),
+      identityType: z
+        .string({ invalid_type_error: "Identity Type is required" })
+        .nullable(),
+      proofOfAddress: z
+        .string({ invalid_type_error: "Proof of Address is required" })
+        .nullable(),
       identityFileUrl: z.string(),
       identityFileUrlBack: z.string(),
       proofOfAddressFileUrl: z.string(),
@@ -457,8 +465,10 @@ export const validateDirectors = z.object({
     },
     { message: "Invalid director's email" }
   ),
-  identityType: z.string(),
-  proofOfAddress: z.string(),
+  identityType: z.string({
+    invalid_type_error: "Identity Type is required",
+  }),
+  proofOfAddress: z.string().nullable(),
   identityFileUrl: z.string(),
   identityFileUrlBack: z.string(),
   proofOfAddressFileUrl: z.string(),
@@ -473,8 +483,8 @@ export const validateShareholder = z.object({
     },
     { message: "Invalid shareholder's email" }
   ),
-  identityType: z.string(),
-  proofOfAddress: z.string(),
+  identityType: z.string({ invalid_type_error: "Identity Type is required" }),
+  proofOfAddress: z.string().nullable(),
   identityFileUrl: z.string(),
   identityFileUrlBack: z.string(),
   proofOfAddressFileUrl: z.string(),


### PR DESCRIPTION
This pull request includes changes to the validation schema in `src/lib/schema.ts` to improve error messaging and validation requirements for identity and address fields.

Validation schema improvements:

* [`src/lib/schema.ts`](diffhunk://#diff-788cfa8897b3d37a0d726b64c66fa8700807c7439dd0be3f73198ef6e0cbb8a0L420-R425): Updated `validateNewBusiness` to include custom error messages for `identityType` and `proofOfAddress` fields. [[1]](diffhunk://#diff-788cfa8897b3d37a0d726b64c66fa8700807c7439dd0be3f73198ef6e0cbb8a0L420-R425) [[2]](diffhunk://#diff-788cfa8897b3d37a0d726b64c66fa8700807c7439dd0be3f73198ef6e0cbb8a0L439-R448)
* [`src/lib/schema.ts`](diffhunk://#diff-788cfa8897b3d37a0d726b64c66fa8700807c7439dd0be3f73198ef6e0cbb8a0L460-R471): Updated `validateDirectors` to include a custom error message for the `identityType` field and made `proofOfAddress` nullable.
* [`src/lib/schema.ts`](diffhunk://#diff-788cfa8897b3d37a0d726b64c66fa8700807c7439dd0be3f73198ef6e0cbb8a0L476-R487): Updated `validateShareholder` to include a custom error message for the `identityType` field and made `proofOfAddress` nullable.