### PR TITLE
Improve Account Info styling and handled account type differentiation properly.

### DIFF
--- a/src/ui/components/SingleAccount/index.tsx
+++ b/src/ui/components/SingleAccount/index.tsx
@@ -640,6 +640,7 @@ export const SingleAccountBody = ({
         trxMeta={trxMeta}
         isUser={isUser}
         revalidate={revalidate}
+        main={location === "own-account" || location === "admin-default"}
       />
 
       <TabsComponent tabs={tabs} mt={40}>
@@ -710,6 +711,7 @@ export const SingleDefaultAccountBody = ({
         trxMeta={trxMeta}
         isUser={!admin}
         revalidate={revalidate}
+        main={location === "own-account" || location === "admin-default"}
       />
 
       <TabsComponent tabs={tabs} mt={40}>
@@ -1004,6 +1006,7 @@ interface AccountInfoProps {
   loadingTrx: boolean;
   account: Account | DefaultAccount | null;
   payout?: boolean;
+  main?: boolean;
   trxMeta: Meta | null;
   isUser?: boolean;
   revalidate?: () => Promise<void>;
@@ -1014,6 +1017,7 @@ export const AccountInfo = ({
   loadingTrx,
   account,
   payout,
+  main,
   trxMeta,
   isUser,
   revalidate,
@@ -1028,6 +1032,12 @@ export const AccountInfo = ({
     Currency: "EUR",
   };
 
+  const accountType = payout
+    ? "Payout Account"
+    : main
+    ? "Main Account"
+    : "Issued Account";
+
   const handleReload = async () => {
     setProcessing(true);
     try {
@@ -1041,7 +1051,12 @@ export const AccountInfo = ({
   };
   return (
     <SimpleGrid cols={{ base: 1, md: 2 }}>
-      <Paper withBorder p={16} radius={4}>
+      <Paper
+        withBorder
+        p={16}
+        radius={4}
+        styles={{ root: { border: "1px solid #eef0f2" } }}
+      >
         <Flex justify="space-between">
           <Stack gap={8}>
             <Text fz={12} fw={400} c="var(--prune-text-gray-400)">
@@ -1063,13 +1078,17 @@ export const AccountInfo = ({
                 c="var(--prune-primary-900)"
                 loading={processing}
                 action={handleReload}
+                variant="light"
+                fz={12}
+                fw={600}
+                radius="xl"
                 leftSection={
                   <ThemeIcon
                     variant="transparent"
                     color="var(--prune-primary-700)"
                     size={20}
                   >
-                    <IconReload />
+                    <IconReload stroke={2} />
                   </ThemeIcon>
                 }
                 td="underline"
@@ -1098,15 +1117,16 @@ export const AccountInfo = ({
                     <IconCircleFilled />
                   </ThemeIcon>
                 }
-                fw={500}
-                fz={14}
+                fw={600}
+                fz={12}
                 tt="capitalize"
               >
-                {payout
+                {/* {payout
                   ? "Payout Account"
                   : getUserType(
                       account?.type as "USER" | "CORPORATE"
-                    ).toLowerCase()}
+                    ).toLowerCase()} */}
+                {accountType}
               </Badge>
             ) : (
               <Skeleton w={100} h={10} />
@@ -1117,13 +1137,19 @@ export const AccountInfo = ({
 
       <SimpleGrid cols={{ base: 1, md: 2 }}>
         {Object.entries(_info).map(([key, value]) => (
-          <Paper key={key} withBorder p={12} radius={4}>
+          <Paper
+            key={key}
+            withBorder
+            p={12}
+            radius={4}
+            styles={{ root: { border: "1px solid #eef0f2" } }}
+          >
             <Stack gap={2}>
               <Text fz={12} fw={400} c="var(--prune-text-gray-400)">
                 {key}
               </Text>
               {!loading || !loadingTrx ? (
-                <Text fz={14} fw={500} c="var(--prune-text-gray-800)">
+                <Text fz={14} fw={600} c="var(--prune-text-gray-800)">
                   {value}
                 </Text>
               ) : (


### PR DESCRIPTION
This pull request includes several changes to the `SingleAccount` component in the `src/ui/components/SingleAccount/index.tsx` file. The most important changes include adding a `main` prop to differentiate account types, updating the styling of the `Paper` component, and modifying the appearance of various UI elements.

### Enhancements to Account Type Handling:
* Added a `main` prop to `SingleAccountBody`, `SingleDefaultAccountBody`, and `AccountInfo` to determine whether the account is a main or an admin default account. [[1]](diffhunk://#diff-9fd825a68aef51f2b68db3723a62cc7ce938791965d89cc5b7555f60989df84bR643) [[2]](diffhunk://#diff-9fd825a68aef51f2b68db3723a62cc7ce938791965d89cc5b7555f60989df84bR714) [[3]](diffhunk://#diff-9fd825a68aef51f2b68db3723a62cc7ce938791965d89cc5b7555f60989df84bR1009)
* Updated the `AccountInfo` component to display the account type based on the `main` and `payout` props. [[1]](diffhunk://#diff-9fd825a68aef51f2b68db3723a62cc7ce938791965d89cc5b7555f60989df84bR1035-R1040) [[2]](diffhunk://#diff-9fd825a68aef51f2b68db3723a62cc7ce938791965d89cc5b7555f60989df84bL1101-R1129)

### UI Styling Improvements:
* Enhanced the `Paper` component with custom border styles. [[1]](diffhunk://#diff-9fd825a68aef51f2b68db3723a62cc7ce938791965d89cc5b7555f60989df84bL1044-R1059) [[2]](diffhunk://#diff-9fd825a68aef51f2b68db3723a62cc7ce938791965d89cc5b7555f60989df84bL1120-R1152)
* Modified the `Button` component within `AccountInfo` to use a lighter variant with a different font size, weight, and radius.

These changes improve the user interface and provide better differentiation between account types.