### PR TITLE
Trading Name on New Business page

### DIFF
--- a/src/app/admin/(dashboard)/businesses/new/BasicInfo.tsx
+++ b/src/app/admin/(dashboard)/businesses/new/BasicInfo.tsx
@@ -96,7 +96,7 @@ export default function BasicInfo({ form }: Props) {
           label="Trade Name"
           placeholder="Enter Business Trade Name"
           {...form.getInputProps("tradingName")}
-          withAsterisk
+          // withAsterisk
         />
 
         <Select


### PR DESCRIPTION
This pull request includes a small change to the `BasicInfo` component in the `src/app/admin/(dashboard)/businesses/new/BasicInfo.tsx` file. The change comments out the `withAsterisk` property for the `TextInput` component for the "Trade Name" field.

* [`src/app/admin/(dashboard)/businesses/new/BasicInfo.tsx`](diffhunk://#diff-2b06a7ca04a53c17c7dd93b44579f72d3579af85f95dfc3dc67b2ae8b34526caL99-R99): Commented out the `withAsterisk` property for the `TextInput` component for the "Trade Name" field. 