### PR TITLE
Remove Save & Continue later

### DIFF
--- a/src/app/admin/(dashboard)/eligibility-center/new/page.tsx
+++ b/src/app/admin/(dashboard)/eligibility-center/new/page.tsx
@@ -260,10 +260,7 @@ function EligibilityCenterNew() {
         <Divider color="var(--prune-text-gray-200)" />
 
         <Flex justify="space-between" align="center">
-          <Flex gap={24}>
-            <SecondaryBtn text="Clear Form" action={form.reset} fw={600} />
-            <SecondaryBtn text="Save and continue later" fw={600} />
-          </Flex>
+          <SecondaryBtn text="Clear Form" action={form.reset} fw={600} />
 
           <PrimaryBtn text="Save" type="submit" fw={600} />
         </Flex>


### PR DESCRIPTION
Remove redundant "Save and continue later" button

The "Save and continue later" button was removed as it was deemed unnecessary for the current workflow, simplifying the UI and reducing clutter