### PR TITLE
fix(NewAccountCard): handle null accountNumber in API request and for…

### DIFF
--- a/src/ui/components/Cards/NewAccountCard.tsx
+++ b/src/ui/components/Cards/NewAccountCard.tsx
@@ -143,7 +143,9 @@ function NewAccountCard({
     try {
       await axios.get(
         currency
-          ? `/accounts/${accountNumber}/balance/dashboard?currency=${currency}`
+          ? `/accounts/${
+              accountNumber ?? walletId
+            }/balance/dashboard?currency=${currency}`
           : `/accounts/${iban}/balance/dashboard`
       );
       revalidate && (await revalidate());
@@ -305,55 +307,59 @@ function NewAccountCard({
               {!loading ? (
                 <Box onClick={handlePropagation}>
                   <CopyButton
-                    value={currency === 'GHS' ? 
-                    `${config.bankIdLabel}: ${config.getBankIdValue({
-                      currency,
-                      companyName,
-                      walletOwner,
-                      walletId,
-                      iban,
-                      bic,
-                      sortCode,
-                      accountNumber,
-                      balance,
-                      loading,
-                    })},\n${config.accountIdLabel}: ${config.getAccountIdValue({
-                      currency,
-                      companyName,
-                      walletOwner,
-                      walletId,
-                      iban,
-                      bic,
-                      sortCode,
-                      accountNumber,
-                      balance,
-                      loading,
-                    })}` :
-                    `${config.bankIdLabel}: ${config.getBankIdValue({
-                      currency,
-                      companyName,
-                      walletOwner,
-                      walletId,
-                      iban,
-                      bic,
-                      sortCode,
-                      accountNumber,
-                      balance,
-                      loading,
-                    })},\nAccount Name: ${companyName},\n${
-                      config.accountIdLabel
-                    }: ${config.getAccountIdValue({
-                      currency,
-                      companyName,
-                      walletOwner,
-                      walletId,
-                      iban,
-                      bic,
-                      sortCode,
-                      accountNumber,
-                      balance,
-                      loading,
-                    })}`}
+                    value={
+                      currency === "GHS"
+                        ? `${config.bankIdLabel}: ${config.getBankIdValue({
+                            currency,
+                            companyName,
+                            walletOwner,
+                            walletId,
+                            iban,
+                            bic,
+                            sortCode,
+                            accountNumber,
+                            balance,
+                            loading,
+                          })},\n${
+                            config.accountIdLabel
+                          }: ${config.getAccountIdValue({
+                            currency,
+                            companyName,
+                            walletOwner,
+                            walletId,
+                            iban,
+                            bic,
+                            sortCode,
+                            accountNumber,
+                            balance,
+                            loading,
+                          })}`
+                        : `${config.bankIdLabel}: ${config.getBankIdValue({
+                            currency,
+                            companyName,
+                            walletOwner,
+                            walletId,
+                            iban,
+                            bic,
+                            sortCode,
+                            accountNumber,
+                            balance,
+                            loading,
+                          })},\nAccount Name: ${companyName},\n${
+                            config.accountIdLabel
+                          }: ${config.getAccountIdValue({
+                            currency,
+                            companyName,
+                            walletOwner,
+                            walletId,
+                            iban,
+                            bic,
+                            sortCode,
+                            accountNumber,
+                            balance,
+                            loading,
+                          })}`
+                    }
                   >
                     {({ copied, copy }) => (
                       <SecondaryBtn

--- a/src/ui/components/SingleAccount/(defaultTabs)/DefaultAccountDetails.tsx
+++ b/src/ui/components/SingleAccount/(defaultTabs)/DefaultAccountDetails.tsx
@@ -105,16 +105,12 @@ export default function DefaultAccountDetails({
 
         {!loading && (
           <CopyButton
-            value={`
-            ${" "}
-            Account Name: ${account?.accountName ?? ""},
-            ${config.accountIdLabel}: ${config.getAccountIdValue(account)},
-            ${config.bankIdLabel}: ${config.getBankIdValue(account)},
-            Bank Name: Prune Payments LTD,
-            Bank Address: Office 7 35-37 Ludgate Hill, London,
-            Bank Country: United Kingdom
-            ${" "}
-            `}
+            value={`Account Name: ${account?.accountName ?? ""}
+${config.accountIdLabel}: ${config.getAccountIdValue(account)}
+${config.bankIdLabel}: ${config.getBankIdValue(account)}
+Bank Name: Prune Payments LTD
+Bank Address: Office 7 35-37 Ludgate Hill, London
+Bank Country: United Kingdom`}
           >
             {({ copied, copy }) => (
               <PrimaryBtn


### PR DESCRIPTION
…mat copy value

Use walletId as fallback when accountNumber is null in balance dashboard API request Improve readability of copy value formatting by breaking into multiple lines