### PR TITLE
fix(hooks): correct type definition for banks state in useUserListOfB…

### DIFF
--- a/src/lib/hooks/accounts.ts
+++ b/src/lib/hooks/accounts.ts
@@ -692,7 +692,7 @@ export function useUserCurrencyGBPAccount(currency: string) {
   return { loading, account, revalidate };
 }
 export function useUserListOfBanks() {
-  const [banks, setBanks] = useState<DefaultAccount | null>(null);
+  const [banks, setBanks] = useState<ListOfBanks[] | null>(null);
   const [loading, setLoading] = useState(true);
 
   async function fetchDefaultAccount() {
@@ -921,6 +921,12 @@ export interface CurrencyAccount {
   AccountRequests: {
     Currency: Record<string, any>;
   };
+}
+
+export interface ListOfBanks {
+  bankCode: string;
+  bankName: string;
+  payoutType: "MobileMoney" | "BankTransfer" | string;
 }
 
 export interface ListCurrencyAccount {


### PR DESCRIPTION
…anks

The useState hook was incorrectly typed as DefaultAccount instead of ListOfBanks[]. This change aligns the type with the actual data structure being used and adds the ListOfBanks interface definition.