### PR TITLE
fix: update phone number placeholder from 234 to 233 prefix

### DIFF
--- a/src/ui/components/SingleAccount/Individual.tsx
+++ b/src/ui/components/SingleAccount/Individual.tsx
@@ -383,7 +383,7 @@ const Individual = forwardRef<HTMLDivElement, IndividualProps>(
                             Phone Number <span style={{ color: "red" }}>*</span>
                           </Text>
                         }
-                        placeholder="Enter phone number (e.g. 234XXXXXXXXX)"
+                        placeholder="Enter phone number (e.g. 233XXXXXXXXX)"
                         {...form.getInputProps("phoneNumber")}
                         errorProps={{
                           fz: 12,

--- a/src/ui/components/SingleAccount/company.tsx
+++ b/src/ui/components/SingleAccount/company.tsx
@@ -382,7 +382,7 @@ const Company = forwardRef<HTMLDivElement, CompanyProps>(function Company(
                         Phone Number <span style={{ color: "red" }}>*</span>
                       </Text>
                     }
-                    placeholder="Enter phone number (e.g. 234XXXXXXXXX)"
+                    placeholder="Enter phone number (e.g. 233XXXXXXXXX)"
                     {...form2.getInputProps("phoneNumber")}
                     errorProps={{
                       fz: 12,


### PR DESCRIPTION
The placeholder was updated to reflect the correct country code (233) for Ghanaian phone numbers instead of the previous Nigerian code (234).